### PR TITLE
Add basic plantation area generation and ground drops

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/commands/PlantationCommand.java
+++ b/src/main/java/org/maks/farmingPlugin/commands/PlantationCommand.java
@@ -2,7 +2,6 @@ package org.maks.farmingPlugin.commands;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -15,7 +14,6 @@ import org.maks.farmingPlugin.farms.FarmType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 public class PlantationCommand implements CommandExecutor, TabCompleter {
     private final FarmingPlugin plugin;
@@ -81,17 +79,15 @@ public class PlantationCommand implements CommandExecutor, TabCompleter {
     }
 
     private void teleportToPlantation(Player player) {
-        Location plantationLocation = getPlantationLocation(player.getUniqueId());
-        
-        if (plantationLocation != null) {
-            player.teleport(plantationLocation);
-            player.sendMessage(ChatColor.GREEN + "Welcome to your plantation!");
-            
-            plugin.getPlantationManager().loadPlayerData(player.getUniqueId());
-            plugin.getOfflineGrowthManager().onPlayerJoin(player.getUniqueId());
-        } else {
-            createPlantationForPlayer(player);
-        }
+        org.maks.farmingPlugin.managers.PlantationAreaManager.PlantationArea area =
+                plugin.getPlantationAreaManager().getOrCreateArea(player);
+
+        Location plantationLocation = area.getCenter();
+        player.teleport(plantationLocation);
+        player.sendMessage(ChatColor.GREEN + "Welcome to your plantation!");
+
+        plugin.getPlantationManager().loadPlayerData(player.getUniqueId());
+        plugin.getOfflineGrowthManager().onPlayerJoin(player.getUniqueId());
     }
 
     private void showPlantationInfo(Player player) {
@@ -206,28 +202,6 @@ public class PlantationCommand implements CommandExecutor, TabCompleter {
         }
     }
 
-    private Location getPlantationLocation(UUID playerId) {
-        World world = plugin.getServer().getWorld("world");
-        if (world == null) return null;
-        
-        String worldName = playerId.toString().substring(0, 8);
-        int x = playerId.hashCode() % 10000;
-        int z = (playerId.hashCode() / 10000) % 10000;
-        
-        return new Location(world, x, 100, z);
-    }
-
-    private void createPlantationForPlayer(Player player) {
-        Location plantationLocation = getPlantationLocation(player.getUniqueId());
-        
-        if (plantationLocation != null) {
-            player.teleport(plantationLocation);
-            player.sendMessage(ChatColor.GREEN + "Welcome to your new plantation!");
-            player.sendMessage(ChatColor.GRAY + "Right-click blocks to interact with your farms!");
-            
-            plugin.getPlantationManager().loadPlayerData(player.getUniqueId());
-        }
-    }
 
     private void sendHelpMessage(Player player) {
         player.sendMessage(ChatColor.GOLD + "=== Plantation Commands ===");

--- a/src/main/java/org/maks/farmingPlugin/gui/PlantationGUI.java
+++ b/src/main/java/org/maks/farmingPlugin/gui/PlantationGUI.java
@@ -159,13 +159,8 @@ public class PlantationGUI implements InventoryHolder {
                 if (materialType != null) {
                     ItemStack materialItem = materialManager.createMaterial(materialType, tier, amount);
                     
-                    if (player.getInventory().firstEmpty() != -1) {
-                        player.getInventory().addItem(materialItem);
-                        collected += amount;
-                    } else {
-                        player.getWorld().dropItem(player.getLocation(), materialItem);
-                        collected += amount;
-                    }
+                    player.getWorld().dropItem(player.getLocation(), materialItem);
+                    collected += amount;
                 }
             }
         }

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -1,0 +1,155 @@
+package org.maks.farmingPlugin.managers;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.maks.farmingPlugin.FarmingPlugin;
+import org.maks.farmingPlugin.database.DatabaseManager;
+import org.maks.farmingPlugin.farms.FarmType;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles allocation and basic management of player plantation areas.
+ * This is a lightweight implementation that provides plot generation,
+ * anchor block placement and simple boundary checks.
+ */
+public class PlantationAreaManager {
+
+    private final FarmingPlugin plugin;
+    private final Map<UUID, PlantationArea> areas = new HashMap<>();
+
+    private final World world;
+    private final int originX, originY, originZ;
+    private final int plotWidth, plotDepth, spacing, gridRows, gridCols;
+    private final Material fenceMaterial, gateMaterial;
+
+    public PlantationAreaManager(FarmingPlugin plugin) {
+        this.plugin = plugin;
+
+        ConfigurationSection base = plugin.getConfig().getConfigurationSection("plantations.base");
+        this.world = Bukkit.getWorld(plugin.getConfig().getString("plantations.world", "world"));
+        ConfigurationSection originSec = base.getConfigurationSection("origin");
+        this.originX = originSec.getInt("x");
+        this.originY = originSec.getInt("y");
+        this.originZ = originSec.getInt("z");
+        ConfigurationSection plotSec = base.getConfigurationSection("plot");
+        this.plotWidth = plotSec.getInt("width");
+        this.plotDepth = plotSec.getInt("depth");
+        this.fenceMaterial = Material.valueOf(plotSec.getString("fence_material", "OAK_FENCE"));
+        this.gateMaterial = Material.valueOf(plotSec.getString("gate_material", "OAK_FENCE_GATE"));
+        this.spacing = base.getInt("spacing");
+        ConfigurationSection gridSec = base.getConfigurationSection("grid");
+        this.gridRows = gridSec.getInt("rows");
+        this.gridCols = gridSec.getInt("cols");
+    }
+
+    /**
+     * Gets existing plantation area for player or creates a new one.
+     */
+    public PlantationArea getOrCreateArea(Player player) {
+        return areas.computeIfAbsent(player.getUniqueId(), uuid -> {
+            DatabaseManager db = plugin.getDatabaseManager();
+            Location origin = db.loadPlayerPlot(uuid).orElseGet(() -> allocateNewPlot(uuid));
+            buildPlot(origin);
+            Map<FarmType, Location> anchors = placeAnchors(origin);
+            return new PlantationArea(uuid, origin, anchors, plotWidth, plotDepth);
+        });
+    }
+
+    private Location allocateNewPlot(UUID uuid) {
+        int index = areas.size();
+        int row = index / gridCols;
+        int col = index % gridCols;
+        int x = originX + col * (plotWidth + spacing);
+        int z = originZ + row * (plotDepth + spacing);
+        Location loc = new Location(world, x, originY, z);
+        plugin.getDatabaseManager().savePlayerPlot(uuid, world.getName(), x, originY, z);
+        return loc;
+    }
+
+    private void buildPlot(Location origin) {
+        if (world == null) return;
+        int x1 = origin.getBlockX();
+        int z1 = origin.getBlockZ();
+        int x2 = x1 + plotWidth - 1;
+        int z2 = z1 + plotDepth - 1;
+        int y = origin.getBlockY();
+
+        for (int x = x1; x <= x2; x++) {
+            world.getBlockAt(x, y, z1).setType(fenceMaterial);
+            world.getBlockAt(x, y, z2).setType(fenceMaterial);
+        }
+        for (int z = z1; z <= z2; z++) {
+            world.getBlockAt(x1, y, z).setType(fenceMaterial);
+            world.getBlockAt(x2, y, z).setType(fenceMaterial);
+        }
+        world.getBlockAt(x1 + plotWidth / 2, y, z1).setType(gateMaterial);
+    }
+
+    private Map<FarmType, Location> placeAnchors(Location origin) {
+        Map<FarmType, Location> anchors = new EnumMap<>(FarmType.class);
+        int[][] offsets = { {2,2}, {4,2}, {6,2}, {2,4}, {4,4}, {6,4}, {4,6} };
+        FarmType[] types = FarmType.values();
+        for (int i = 0; i < Math.min(types.length, offsets.length); i++) {
+            Location loc = origin.clone().add(offsets[i][0], 0, offsets[i][1]);
+            if (world != null) {
+                world.getBlockAt(loc).setType(types[i].getBlockType());
+            }
+            anchors.put(types[i], loc);
+        }
+        return anchors;
+    }
+
+    public boolean isLocationInPlantation(UUID owner, Location loc) {
+        PlantationArea area = areas.get(owner);
+        return area != null && area.contains(loc);
+    }
+
+    public int getFarmInstanceFromLocation(UUID owner, FarmType type, Location loc) {
+        // Each anchor represents instance #1 for that farm type in this basic implementation
+        return 1;
+    }
+
+    public Location getAnchor(UUID owner, FarmType type) {
+        PlantationArea area = areas.get(owner);
+        return area != null ? area.anchors.get(type) : null;
+    }
+
+    /** Represents a single player's plantation plot. */
+    public static class PlantationArea {
+        private final UUID owner;
+        private final Location origin;
+        private final Map<FarmType, Location> anchors;
+        private final int width;
+        private final int depth;
+
+        PlantationArea(UUID owner, Location origin, Map<FarmType, Location> anchors, int width, int depth) {
+            this.owner = owner;
+            this.origin = origin;
+            this.anchors = anchors;
+            this.width = width;
+            this.depth = depth;
+        }
+
+        public Location getCenter() {
+            return origin.clone().add(width / 2.0, 1, depth / 2.0);
+        }
+
+        boolean contains(Location loc) {
+            if (loc == null || origin.getWorld() == null) return false;
+            if (!loc.getWorld().equals(origin.getWorld())) return false;
+            int x = loc.getBlockX();
+            int z = loc.getBlockZ();
+            int x1 = origin.getBlockX();
+            int z1 = origin.getBlockZ();
+            return x >= x1 && x < x1 + width && z >= z1 && z < z1 + depth;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -229,3 +229,30 @@ gui:
   secondary_color: "&7"
   success_color: "&a"
   error_color: "&c"
+
+plantations:
+  world: "world"
+  base:
+    origin:
+      x: 2000
+      y: 64
+      z: 2000
+    plot:
+      width: 17
+      depth: 17
+      fence_material: "OAK_FENCE"
+      gate_material: "OAK_FENCE_GATE"
+    spacing: 6
+    grid:
+      rows: 100
+      cols: 100
+  protection:
+    block_entry: true
+    block_build: true
+  holograms:
+    enabled: true
+    title: "&e{farm_display}"
+    running: "&7Next: &a{time_left}"
+    ready: "&a&lREADY! &7Click to collect"
+  drop:
+    radius: 0.6


### PR DESCRIPTION
## Summary
- create player plot persistence and add plantation area generation
- drop collected materials on the ground instead of into inventories
- teleport players to generated plots when using plantation command

## Testing
- `mvn -q package` *(fails: PluginResolutionException, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5282c4a4832a9d3a583fc8156d21