### PR TITLE
Ensure MySQL settings honor configuration file

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/database/DatabaseManager.java
+++ b/src/main/java/org/maks/farmingPlugin/database/DatabaseManager.java
@@ -25,10 +25,17 @@ public class DatabaseManager {
     }
 
     private void loadDatabaseSettings() {
-        host = plugin.getConfig().getString("database.host", "localhost");
+        // Reload configuration to ensure we're reading latest values
+        plugin.reloadConfig();
+
+        // Support both legacy and new config keys
+        host = plugin.getConfig().getString("database.host",
+            plugin.getConfig().getString("database.hostname", "localhost"));
         port = plugin.getConfig().getInt("database.port", 3306);
-        database = plugin.getConfig().getString("database.database", "plantation");
-        username = plugin.getConfig().getString("database.username", "root");
+        database = plugin.getConfig().getString("database.name",
+            plugin.getConfig().getString("database.database", "plantation"));
+        username = plugin.getConfig().getString("database.user",
+            plugin.getConfig().getString("database.username", "root"));
         password = plugin.getConfig().getString("database.password", "");
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,8 +5,9 @@
 database:
   host: localhost
   port: 3306
-  database: plantation
-  username: root
+  # "name" and "user" keys are also accepted for compatibility
+  name: plantation
+  user: root
   password: ""
 
 # Plantation world and layout settings


### PR DESCRIPTION
## Summary
- reload plugin config before reading DB settings
- support `database.name`/`database.user` keys and legacy alternatives
- document alternate keys in default config

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad59d5b994832aab60ddd83e1fb8f9