### PR TITLE
Prefix database tables with farming

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,16 +158,16 @@ Każda farma może osiągnąć poziom 10:
 ## 🗄️ Struktura Bazy Danych
 
 ### Główne Tabele
-- `player_plantations` - Dane farm graczy
-- `player_materials` - Materiały graczy
-- `plantation_storage` - Przechowywane materiały w farmach
-- `player_plots` - Lokalizacje plantacji
-- `farm_anchors` - Pozycje farm
-- `farm_upgrades` - Historia ulepszeń
-- `player_stats` - Statystyki graczy
-- `harvest_log` - Logi zbiorów
-- `farm_unlocks` - Odblokowane farmy
-- `player_settings` - Ustawienia graczy
+- `farming_player_plantations` - Dane farm graczy
+- `farming_player_materials` - Materiały graczy
+- `farming_plantation_storage` - Przechowywane materiały w farmach
+- `farming_player_plots` - Lokalizacje plantacji
+- `farming_farm_anchors` - Pozycje farm
+- `farming_farm_upgrades` - Historia ulepszeń
+- `farming_player_stats` - Statystyki graczy
+- `farming_harvest_log` - Logi zbiorów
+- `farming_farm_unlocks` - Odblokowane farmy
+- `farming_player_settings` - Ustawienia graczy
 
 ## 🔐 Permisje
 

--- a/src/main/java/org/maks/farmingPlugin/commands/PlantationCommand.java
+++ b/src/main/java/org/maks/farmingPlugin/commands/PlantationCommand.java
@@ -233,7 +233,7 @@ public class PlantationCommand implements CommandExecutor, TabCompleter {
         player.sendMessage(ChatColor.GOLD + "╚════════════════════════════════════╝");
         
         try {
-            String sql = "SELECT * FROM player_stats WHERE uuid = ?";
+            String sql = "SELECT * FROM farming_player_stats WHERE uuid = ?";
             var stmt = plugin.getDatabaseManager().prepareStatement(sql);
             stmt.setString(1, player.getUniqueId().toString());
             var rs = stmt.executeQuery();
@@ -338,8 +338,8 @@ public class PlantationCommand implements CommandExecutor, TabCompleter {
             plugin.getPlantationManager().getPlayerFarms(targetUuid).clear();
             
             // Clear from database
-            String[] tables = {"player_plantations", "plantation_storage", "farm_anchors", 
-                              "player_materials", "player_stats", "farm_unlocks"};
+            String[] tables = {"farming_player_plantations", "farming_plantation_storage", "farming_farm_anchors", 
+                              "farming_player_materials", "farming_player_stats", "farming_farm_unlocks"};
             
             for (String table : tables) {
                 String sql = "DELETE FROM " + table + " WHERE uuid = ?";
@@ -563,7 +563,7 @@ public class PlantationCommand implements CommandExecutor, TabCompleter {
         player.sendMessage(ChatColor.GOLD + "╚════════════════════════════════════╝");
         
         try {
-            String sql = "SELECT uuid, total_materials_collected FROM player_stats " +
+            String sql = "SELECT uuid, total_materials_collected FROM farming_player_stats " +
                         "ORDER BY total_materials_collected DESC LIMIT 10";
             var stmt = plugin.getDatabaseManager().prepareStatement(sql);
             var rs = stmt.executeQuery();

--- a/src/main/java/org/maks/farmingPlugin/gui/PlayerSettingsGUI.java
+++ b/src/main/java/org/maks/farmingPlugin/gui/PlayerSettingsGUI.java
@@ -141,7 +141,7 @@ public class PlayerSettingsGUI implements InventoryHolder {
         
         // Get player statistics from database
         try {
-            String sql = "SELECT * FROM player_stats WHERE uuid = ?";
+            String sql = "SELECT * FROM farming_player_stats WHERE uuid = ?";
             var stmt = plugin.getDatabaseManager().prepareStatement(sql);
             stmt.setString(1, player.getUniqueId().toString());
             var rs = stmt.executeQuery();

--- a/src/main/java/org/maks/farmingPlugin/gui/QuickSellGUI.java
+++ b/src/main/java/org/maks/farmingPlugin/gui/QuickSellGUI.java
@@ -132,7 +132,7 @@ public class QuickSellGUI implements InventoryHolder {
         
         // Get player's total earnings from database
         try {
-            String sql = "SELECT total_money_earned FROM player_stats WHERE uuid = ?";
+            String sql = "SELECT total_money_earned FROM farming_player_stats WHERE uuid = ?";
             var stmt = plugin.getDatabaseManager().prepareStatement(sql);
             stmt.setString(1, player.getUniqueId().toString());
             var rs = stmt.executeQuery();

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -106,7 +106,7 @@ public class PlantationAreaManager {
     private void loadAllPlayerAreas() {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
-                String sql = "SELECT DISTINCT uuid FROM player_plots";
+                String sql = "SELECT DISTINCT uuid FROM farming_player_plots";
                 PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery();
                 
@@ -144,7 +144,7 @@ public class PlantationAreaManager {
         Map<FarmType, Map<Integer, FarmAnchor>> anchors = new EnumMap<>(FarmType.class);
         
         try {
-            String sql = "SELECT farm_type, instance_id, anchor_x, anchor_y, anchor_z FROM farm_anchors WHERE uuid = ?";
+            String sql = "SELECT farm_type, instance_id, anchor_x, anchor_y, anchor_z FROM farming_farm_anchors WHERE uuid = ?";
             PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);
             stmt.setString(1, uuid.toString());
             ResultSet rs = stmt.executeQuery();
@@ -236,7 +236,7 @@ public class PlantationAreaManager {
     private void saveFarmAnchor(UUID uuid, FarmType type, int instanceId, Location loc) {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
-                String sql = "INSERT INTO farm_anchors (uuid, farm_type, instance_id, anchor_x, anchor_y, anchor_z) " +
+                String sql = "INSERT INTO farming_farm_anchors (uuid, farm_type, instance_id, anchor_x, anchor_y, anchor_z) " +
                            "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE " +
                            "anchor_x = VALUES(anchor_x), anchor_y = VALUES(anchor_y), anchor_z = VALUES(anchor_z)";
                 PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
@@ -145,7 +145,7 @@ public class PlantationManager {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
                 // Load farms
-                String sql = "SELECT * FROM player_plantations WHERE uuid = ?";
+                String sql = "SELECT * FROM farming_player_plantations WHERE uuid = ?";
                 PreparedStatement stmt = database.prepareStatement(sql);
                 stmt.setString(1, playerUuid.toString());
                 
@@ -213,7 +213,7 @@ public class PlantationManager {
 
     private Map<String, Integer> loadStoredMaterials(UUID playerUuid, FarmType farmType, int instanceId) {
         try {
-            String sql = "SELECT stored_materials_json FROM plantation_storage WHERE uuid = ? AND farm_type = ? AND instance_id = ?";
+            String sql = "SELECT stored_materials_json FROM farming_plantation_storage WHERE uuid = ? AND farm_type = ? AND instance_id = ?";
             PreparedStatement stmt = database.prepareStatement(sql);
             stmt.setString(1, playerUuid.toString());
             stmt.setString(2, farmType.getId());
@@ -245,7 +245,7 @@ public class PlantationManager {
             try {
                 for (FarmInstance farm : farms) {
                     // Save farm data
-                    String sql = "INSERT INTO player_plantations (uuid, farm_type, instance_id, level, efficiency, last_harvest, total_harvests, exp) " +
+                    String sql = "INSERT INTO farming_player_plantations (uuid, farm_type, instance_id, level, efficiency, last_harvest, total_harvests, exp) " +
                                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE " +
                                "level = VALUES(level), efficiency = VALUES(efficiency), last_harvest = VALUES(last_harvest), " +
                                "total_harvests = VALUES(total_harvests), exp = VALUES(exp)";
@@ -274,7 +274,7 @@ public class PlantationManager {
     private void saveStoredMaterials(UUID playerUuid, FarmInstance farm) throws SQLException {
         String json = gson.toJson(farm.getStoredMaterials());
         
-        String sql = "INSERT INTO plantation_storage (uuid, farm_type, instance_id, stored_materials_json, auto_collect) " +
+        String sql = "INSERT INTO farming_plantation_storage (uuid, farm_type, instance_id, stored_materials_json, auto_collect) " +
                    "VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE " +
                    "stored_materials_json = VALUES(stored_materials_json), auto_collect = VALUES(auto_collect)";
         


### PR DESCRIPTION
## Summary
- Prefix all database tables with `farming_` and adjust queries accordingly
- Update commands and managers to use new prefixed tables
- Document new table names in README
- Remove migration logic to avoid modifying existing tables

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d4cba6c832abedf1e0f1d873bf3