### PR TITLE
Replace unsupported short grass material

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -342,7 +342,10 @@ public class PlantationAreaManager {
             
             Block decorBlock = world.getBlockAt(randX, y, randZ);
             if (decorBlock.getType() == Material.AIR) {
-                Material[] decorations = {Material.DANDELION, Material.POPPY, Material.SHORT_GRASS, Material.TALL_GRASS};
+                Material shortGrass = Material.matchMaterial("SHORT_GRASS");
+                Material[] decorations = shortGrass != null
+                        ? new Material[]{Material.DANDELION, Material.POPPY, shortGrass, Material.TALL_GRASS}
+                        : new Material[]{Material.DANDELION, Material.POPPY, Material.TALL_GRASS};
                 decorBlock.setType(decorations[random.nextInt(decorations.length)]);
             }
         }


### PR DESCRIPTION
## Summary
- Handle missing `SHORT_GRASS` Material by looking it up at runtime and omitting it when unavailable to avoid runtime errors

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad60c3db68832aa6fb40027baec183