### PR TITLE
Simplify plantation permission system

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Każda farma może osiągnąć poziom 10:
 
 ## 🔐 Permisje
 
-- `plantation.access` - Dostęp do systemu plantacji
+- `plantation.use` - Dostęp do systemu plantacji
 - `plantation.admin` - Komendy administracyjne
 - `plantation.admin.build` - Budowanie na cudzych plantacjach
 - `plantation.bypass.limit` - Bypass limitów instancji

--- a/src/main/java/org/maks/farmingPlugin/FarmingPlugin.java
+++ b/src/main/java/org/maks/farmingPlugin/FarmingPlugin.java
@@ -7,6 +7,7 @@ import org.maks.farmingPlugin.database.DatabaseManager;
 import org.maks.farmingPlugin.listeners.PlantationListeners;
 import org.maks.farmingPlugin.managers.*;
 import org.maks.farmingPlugin.materials.MaterialManager;
+import org.maks.farmingPlugin.fruits.FruitType;
 
 import java.util.logging.Level;
 
@@ -111,6 +112,11 @@ public final class FarmingPlugin extends JavaPlugin {
     }
 
     private void initializeManagers() throws Exception {
+        // Initialize fruit types from config
+        getLogger().info("Loading fruit types from config...");
+        FruitType.initialize(this);
+        getLogger().info("✔ Fruit types loaded!");
+
         // Material Manager
         getLogger().info("Initializing material system...");
         materialManager = new MaterialManager(this);

--- a/src/main/java/org/maks/farmingPlugin/commands/PlantationCommand.java
+++ b/src/main/java/org/maks/farmingPlugin/commands/PlantationCommand.java
@@ -16,6 +16,7 @@ import org.maks.farmingPlugin.farms.FarmType;
 import org.maks.farmingPlugin.gui.PlantationGUI;
 import org.maks.farmingPlugin.gui.PlayerSettingsGUI;
 import org.maks.farmingPlugin.gui.QuickSellGUI;
+import org.maks.farmingPlugin.gui.PlantationTeleportGUI;
 import org.maks.farmingPlugin.materials.MaterialType;
 import org.maks.farmingPlugin.managers.PlantationAreaManager;
 
@@ -37,13 +38,14 @@ public class PlantationCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
-        if (!player.hasPermission("plantation.access")) {
-            player.sendMessage(ChatColor.RED + "You don't have permission to use plantation commands!");
+        if (!player.hasPermission("plantation.use") && !player.hasPermission("plantation.admin")) {
+            player.sendMessage(ChatColor.RED + "You need to visit the Farm NPC to use this!");
             return true;
         }
 
         if (args.length == 0) {
-            teleportToPlantation(player);
+            PlantationTeleportGUI gui = new PlantationTeleportGUI(plugin, player);
+            player.openInventory(gui.getInventory());
             return true;
         }
 

--- a/src/main/java/org/maks/farmingPlugin/gui/PlantationTeleportGUI.java
+++ b/src/main/java/org/maks/farmingPlugin/gui/PlantationTeleportGUI.java
@@ -1,0 +1,287 @@
+package org.maks.farmingPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.maks.farmingPlugin.FarmingPlugin;
+import org.maks.farmingPlugin.farms.FarmInstance;
+import org.maks.farmingPlugin.farms.FarmType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PlantationTeleportGUI implements InventoryHolder {
+    private final FarmingPlugin plugin;
+    private final Player player;
+    private final Inventory inventory;
+
+    public PlantationTeleportGUI(FarmingPlugin plugin, Player player) {
+        this.plugin = plugin;
+        this.player = player;
+
+        String title = ChatColor.DARK_GREEN + "🌱 Plantation Portal";
+        this.inventory = Bukkit.createInventory(this, 45, title);
+
+        setupGUI();
+    }
+
+    private void setupGUI() {
+        fillBackground();
+        addPlayerInfo();
+        addTeleportButton();
+        addFarmInfo();
+        addControlButtons();
+    }
+
+    private void fillBackground() {
+        ItemStack borderItem = createItem(Material.GREEN_STAINED_GLASS_PANE, " ", null);
+
+        // Fill borders
+        for (int i = 0; i < 9; i++) {
+            inventory.setItem(i, borderItem);
+            inventory.setItem(i + 36, borderItem);
+        }
+        for (int i = 9; i < 36; i += 9) {
+            inventory.setItem(i, borderItem);
+            inventory.setItem(i + 8, borderItem);
+        }
+
+        // Decorative pattern
+        ItemStack decorItem = createItem(Material.LIME_STAINED_GLASS_PANE, " ", null);
+        inventory.setItem(10, decorItem);
+        inventory.setItem(16, decorItem);
+        inventory.setItem(28, decorItem);
+        inventory.setItem(34, decorItem);
+    }
+
+    private void addPlayerInfo() {
+        // Player head with stats
+        ItemStack playerHead = new ItemStack(Material.PLAYER_HEAD);
+        SkullMeta skullMeta = (SkullMeta) playerHead.getItemMeta();
+
+        if (skullMeta != null) {
+            skullMeta.setOwningPlayer(player);
+            skullMeta.setDisplayName(ChatColor.GOLD + player.getName() + "'s Stats");
+
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "━━━━━━━━━━━━━━━━━━");
+
+            // Get player stats
+            double balance = plugin.getEconomyManager().getBalance(player);
+            lore.add(ChatColor.GREEN + "💰 Balance: " + ChatColor.GOLD +
+                    plugin.getEconomyManager().formatMoney(balance));
+
+            // Get farm count
+            List<FarmInstance> farms = plugin.getPlantationManager().getPlayerFarms(player.getUniqueId());
+            lore.add(ChatColor.AQUA + "🌾 Active Farms: " + ChatColor.WHITE + farms.size());
+
+            // Check if any farms ready
+            long readyCount = farms.stream().filter(FarmInstance::isReadyForHarvest).count();
+            if (readyCount > 0) {
+                lore.add(ChatColor.GREEN + "✦ " + readyCount + " ready to harvest!");
+            }
+
+            lore.add(ChatColor.GRAY + "━━━━━━━━━━━━━━━━━━");
+
+            skullMeta.setLore(lore);
+            playerHead.setItemMeta(skullMeta);
+        }
+
+        inventory.setItem(13, playerHead);
+    }
+
+    private void addTeleportButton() {
+        ItemStack teleportButton = createItem(Material.ENDER_PEARL,
+                ChatColor.GREEN + "§l➤ TELEPORT TO PLANTATION",
+                null);
+        ItemMeta meta = teleportButton.getItemMeta();
+
+        List<String> lore = new ArrayList<>();
+
+        // Check level requirement
+        int playerLevel = player.getLevel();
+        int requiredLevel = plugin.getConfig().getInt("teleport.minimum_level", 85);
+
+        if (playerLevel >= requiredLevel) {
+            lore.add(ChatColor.GREEN + "✔ Level requirement met!");
+            lore.add(ChatColor.GRAY + "Your level: " + ChatColor.WHITE + playerLevel);
+            lore.add("");
+            lore.add(ChatColor.YELLOW + "Click to teleport!");
+            lore.add(ChatColor.GRAY + "Travel to your plantation");
+
+            meta.addEnchant(Enchantment.DURABILITY, 1, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        } else {
+            lore.add(ChatColor.RED + "✘ Level requirement not met!");
+            lore.add(ChatColor.GRAY + "Your level: " + ChatColor.WHITE + playerLevel);
+            lore.add(ChatColor.GRAY + "Required: " + ChatColor.RED + requiredLevel);
+            lore.add("");
+            lore.add(ChatColor.RED + "You must be at least level " + requiredLevel + "!");
+
+            // Change to barrier if not enough level
+            teleportButton.setType(Material.BARRIER);
+            meta.setDisplayName(ChatColor.RED + "§l✘ CANNOT TELEPORT");
+        }
+
+        meta.setLore(lore);
+        teleportButton.setItemMeta(meta);
+
+        inventory.setItem(22, teleportButton);
+    }
+
+    private void addFarmInfo() {
+        // Farm Types Overview
+        ItemStack farmInfo = createItem(Material.WHEAT,
+                ChatColor.YELLOW + "🌾 Farm Types",
+                null);
+        ItemMeta meta = farmInfo.getItemMeta();
+
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Available farm types:");
+        lore.add("");
+
+        for (FarmType type : FarmType.values()) {
+            boolean unlocked = type == FarmType.BERRY_ORCHARDS ||
+                             plugin.getDatabaseManager().isFarmUnlocked(player.getUniqueId(), type.getId());
+
+            String status = unlocked ? ChatColor.GREEN + "✔" : ChatColor.RED + "✘";
+            String name = unlocked ? ChatColor.GREEN + type.getDisplayName() :
+                         ChatColor.GRAY + type.getDisplayName();
+
+            lore.add(status + " " + name);
+        }
+
+        meta.setLore(lore);
+        farmInfo.setItemMeta(meta);
+
+        inventory.setItem(20, farmInfo);
+
+        // Quick Stats
+        ItemStack quickStats = createItem(Material.EMERALD,
+                ChatColor.AQUA + "📊 Quick Stats",
+                null);
+        ItemMeta statsMeta = quickStats.getItemMeta();
+
+        List<String> statsLore = new ArrayList<>();
+        try {
+            String sql = "SELECT total_harvests, total_materials_collected FROM farming_player_stats WHERE uuid = ?";
+            var stmt = plugin.getDatabaseManager().prepareStatement(sql);
+            stmt.setString(1, player.getUniqueId().toString());
+            var rs = stmt.executeQuery();
+
+            if (rs.next()) {
+                statsLore.add(ChatColor.GRAY + "Total Harvests: " + ChatColor.GREEN +
+                            String.format("%,d", rs.getLong("total_harvests")));
+                statsLore.add(ChatColor.GRAY + "Materials: " + ChatColor.AQUA +
+                            String.format("%,d", rs.getLong("total_materials_collected")));
+            } else {
+                statsLore.add(ChatColor.GRAY + "No data yet!");
+                statsLore.add(ChatColor.GRAY + "Start farming to earn!");
+            }
+
+            rs.close();
+            stmt.close();
+        } catch (Exception e) {
+            statsLore.add(ChatColor.RED + "Error loading stats");
+        }
+
+        statsMeta.setLore(statsLore);
+        quickStats.setItemMeta(statsMeta);
+
+        inventory.setItem(24, quickStats);
+    }
+
+    private void addControlButtons() {
+        // Info button
+        ItemStack infoButton = createItem(Material.BOOK,
+                ChatColor.YELLOW + "ℹ Information",
+                null);
+        ItemMeta infoMeta = infoButton.getItemMeta();
+
+        List<String> infoLore = new ArrayList<>();
+        infoLore.add(ChatColor.GRAY + "Learn about farming!");
+        infoLore.add("");
+        infoLore.add(ChatColor.WHITE + "• Grow crops over time");
+        infoLore.add(ChatColor.WHITE + "• Harvest fruits to sell");
+        infoLore.add(ChatColor.WHITE + "• Unlock new farm types");
+        infoLore.add(ChatColor.WHITE + "• Upgrade for better yields");
+
+        infoMeta.setLore(infoLore);
+        infoButton.setItemMeta(infoMeta);
+
+        inventory.setItem(30, infoButton);
+
+        // Commands button
+        ItemStack commandsButton = createItem(Material.COMMAND_BLOCK,
+                ChatColor.AQUA + "📋 Commands",
+                null);
+        ItemMeta cmdMeta = commandsButton.getItemMeta();
+
+        List<String> cmdLore = new ArrayList<>();
+        cmdLore.add(ChatColor.GREEN + "/plantation info" + ChatColor.GRAY + " - View farms");
+        cmdLore.add(ChatColor.GREEN + "/plantation stats" + ChatColor.GRAY + " - Statistics");
+        cmdLore.add(ChatColor.GREEN + "/plantation settings" + ChatColor.GRAY + " - Settings");
+        cmdLore.add(ChatColor.GREEN + "/plantation quicksell" + ChatColor.GRAY + " - Sell fruits");
+        cmdLore.add(ChatColor.GREEN + "/plantation help" + ChatColor.GRAY + " - Get help");
+
+        cmdMeta.setLore(cmdLore);
+        commandsButton.setItemMeta(cmdMeta);
+
+        inventory.setItem(32, commandsButton);
+
+        // Close button
+        ItemStack closeButton = createItem(Material.BARRIER,
+                ChatColor.RED + "✘ Close",
+                null);
+        ItemMeta closeMeta = closeButton.getItemMeta();
+
+        List<String> closeLore = new ArrayList<>();
+        closeLore.add(ChatColor.GRAY + "Close this menu");
+
+        closeMeta.setLore(closeLore);
+        closeButton.setItemMeta(closeMeta);
+
+        inventory.setItem(40, closeButton);
+    }
+
+    public boolean canTeleport() {
+        int playerLevel = player.getLevel();
+        int requiredLevel = plugin.getConfig().getInt("teleport.minimum_level", 85);
+
+        if (!plugin.getConfig().getBoolean("teleport.require_level", true)) {
+            return true;
+        }
+
+        return playerLevel >= requiredLevel;
+    }
+
+    private ItemStack createItem(Material material, String name, List<String> lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+
+        if (meta != null) {
+            meta.setDisplayName(name);
+            if (lore != null) {
+                meta.setLore(lore);
+            }
+            item.setItemMeta(meta);
+        }
+
+        return item;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+}
+

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -1,10 +1,12 @@
 package org.maks.farmingPlugin.managers;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.maks.farmingPlugin.FarmingPlugin;
@@ -17,14 +19,11 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Enhanced plantation area manager with proper instance support and layout
- */
 public class PlantationAreaManager {
 
     private final FarmingPlugin plugin;
     private final Map<UUID, PlantationArea> areas = new ConcurrentHashMap<>();
-    
+
     private final World world;
     private final int originX, originY, originZ;
     private final int plotWidth, plotDepth, spacing, gridRows, gridCols;
@@ -32,42 +31,42 @@ public class PlantationAreaManager {
 
     // Farm layout configuration - positions for different farm types and instances
     private static final Map<FarmType, List<int[]>> FARM_LAYOUT = new HashMap<>();
-    
+
     static {
         // Berry Orchards - 6 instances (most common, front area)
         FARM_LAYOUT.put(FarmType.BERRY_ORCHARDS, Arrays.asList(
             new int[]{2, 2}, new int[]{4, 2}, new int[]{6, 2},
             new int[]{2, 4}, new int[]{4, 4}, new int[]{6, 4}
         ));
-        
+
         // Melon Groves - 6 instances (second row)
         FARM_LAYOUT.put(FarmType.MELON_GROVES, Arrays.asList(
             new int[]{8, 2}, new int[]{10, 2}, new int[]{8, 4},
             new int[]{10, 4}, new int[]{8, 6}, new int[]{10, 6}
         ));
-        
+
         // Fungal Caverns - 6 instances (third area)
         FARM_LAYOUT.put(FarmType.FUNGAL_CAVERNS, Arrays.asList(
             new int[]{2, 6}, new int[]{4, 6}, new int[]{6, 6},
             new int[]{2, 8}, new int[]{4, 8}, new int[]{6, 8}
         ));
-        
+
         // Pumpkin Patches - 6 instances
         FARM_LAYOUT.put(FarmType.PUMPKIN_PATCHES, Arrays.asList(
             new int[]{8, 8}, new int[]{10, 8}, new int[]{8, 10},
             new int[]{10, 10}, new int[]{7, 9}, new int[]{9, 9}
         ));
-        
+
         // Mystic Gardens - 3 instances (rare, special area)
         FARM_LAYOUT.put(FarmType.MYSTIC_GARDENS, Arrays.asList(
             new int[]{3, 10}, new int[]{5, 10}, new int[]{4, 11}
         ));
-        
+
         // Ancient Mangroves - 3 instances (very rare)
         FARM_LAYOUT.put(FarmType.ANCIENT_MANGROVES, Arrays.asList(
             new int[]{2, 11}, new int[]{6, 11}, new int[]{4, 12}
         ));
-        
+
         // Desert Sanctuaries - 1 instance (legendary, center-back)
         FARM_LAYOUT.put(FarmType.DESERT_SANCTUARIES, Arrays.asList(
             new int[]{6, 9}
@@ -79,45 +78,42 @@ public class PlantationAreaManager {
 
         ConfigurationSection base = plugin.getConfig().getConfigurationSection("plantations.base");
         this.world = Bukkit.getWorld(plugin.getConfig().getString("plantations.world", "world"));
-        
+
         ConfigurationSection originSec = base.getConfigurationSection("origin");
         this.originX = originSec.getInt("x");
         this.originY = originSec.getInt("y");
         this.originZ = originSec.getInt("z");
-        
+
         ConfigurationSection plotSec = base.getConfigurationSection("plot");
-        this.plotWidth = plotSec.getInt("width", 16);  // Increased default size
+        this.plotWidth = plotSec.getInt("width", 16);
         this.plotDepth = plotSec.getInt("depth", 16);
         this.fenceMaterial = Material.valueOf(plotSec.getString("fence_material", "OAK_FENCE"));
         this.gateMaterial = Material.valueOf(plotSec.getString("gate_material", "OAK_FENCE_GATE"));
-        
+
         this.spacing = base.getInt("spacing");
-        
+
         ConfigurationSection gridSec = base.getConfigurationSection("grid");
         this.gridRows = gridSec.getInt("rows");
         this.gridCols = gridSec.getInt("cols");
-        
+
         loadAllPlayerAreas();
     }
 
-    /**
-     * Load all existing player areas from database on startup
-     */
     private void loadAllPlayerAreas() {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
                 String sql = "SELECT DISTINCT uuid FROM farming_player_plots";
                 PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery();
-                
+
                 while (rs.next()) {
                     UUID uuid = UUID.fromString(rs.getString("uuid"));
                     loadPlayerArea(uuid);
                 }
-                
+
                 rs.close();
                 stmt.close();
-                
+
                 plugin.getLogger().info("Loaded " + areas.size() + " player plantation areas");
             } catch (SQLException e) {
                 plugin.getLogger().warning("Failed to load player areas: " + e.getMessage());
@@ -125,9 +121,6 @@ public class PlantationAreaManager {
         });
     }
 
-    /**
-     * Load a specific player's area from database
-     */
     private void loadPlayerArea(UUID uuid) {
         Optional<Location> savedLocation = plugin.getDatabaseManager().loadPlayerPlot(uuid);
         if (savedLocation.isPresent()) {
@@ -137,22 +130,19 @@ public class PlantationAreaManager {
         }
     }
 
-    /**
-     * Load existing farm anchors for a player
-     */
     private Map<FarmType, Map<Integer, FarmAnchor>> loadFarmAnchors(UUID uuid, Location origin) {
         Map<FarmType, Map<Integer, FarmAnchor>> anchors = new EnumMap<>(FarmType.class);
-        
+
         try {
             String sql = "SELECT farm_type, instance_id, anchor_x, anchor_y, anchor_z FROM farming_farm_anchors WHERE uuid = ?";
             PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);
             stmt.setString(1, uuid.toString());
             ResultSet rs = stmt.executeQuery();
-            
+
             while (rs.next()) {
                 FarmType type = FarmType.fromId(rs.getString("farm_type"));
                 int instanceId = rs.getInt("instance_id");
-                
+
                 if (type != null) {
                     Location anchorLoc = new Location(
                         world,
@@ -160,37 +150,92 @@ public class PlantationAreaManager {
                         rs.getInt("anchor_y"),
                         rs.getInt("anchor_z")
                     );
-                    
+
                     anchors.computeIfAbsent(type, k -> new HashMap<>())
                            .put(instanceId, new FarmAnchor(anchorLoc, type, instanceId));
                 }
             }
-            
+
             rs.close();
             stmt.close();
         } catch (SQLException e) {
             plugin.getLogger().warning("Failed to load farm anchors: " + e.getMessage());
         }
-        
+
         return anchors;
     }
 
-    /**
-     * Gets existing plantation area for player or creates a new one
-     */
     public PlantationArea getOrCreateArea(Player player) {
         return areas.computeIfAbsent(player.getUniqueId(), uuid -> {
             DatabaseManager db = plugin.getDatabaseManager();
             Location origin = db.loadPlayerPlot(uuid).orElseGet(() -> allocateNewPlot(uuid));
             buildPlotStructure(origin);
+            placeFarmBlocks(origin, uuid); // Place all farm blocks on first creation
             Map<FarmType, Map<Integer, FarmAnchor>> anchors = new EnumMap<>(FarmType.class);
             return new PlantationArea(uuid, origin, anchors, plotWidth, plotDepth);
         });
     }
 
     /**
-     * Get or create a specific farm anchor
+     * Place all farm type blocks with unlock signs
      */
+    private void placeFarmBlocks(Location origin, UUID playerUuid) {
+        if (world == null) return;
+
+        // Place Berry Orchards (always unlocked)
+        List<int[]> berryPositions = FARM_LAYOUT.get(FarmType.BERRY_ORCHARDS);
+        if (berryPositions != null) {
+            for (int i = 0; i < berryPositions.size(); i++) {
+                int[] pos = berryPositions.get(i);
+                Location farmLoc = origin.clone().add(pos[0], 0, pos[1]);
+                Block block = world.getBlockAt(farmLoc);
+                block.setType(FarmType.BERRY_ORCHARDS.getBlockType());
+            }
+        }
+
+        // Place other farm types with signs (locked initially)
+        for (FarmType farmType : FarmType.values()) {
+            if (farmType == FarmType.BERRY_ORCHARDS) continue; // Already placed
+
+            List<int[]> positions = FARM_LAYOUT.get(farmType);
+            if (positions != null && !positions.isEmpty()) {
+                // Place first instance location with a sign
+                int[] pos = positions.get(0);
+                Location farmLoc = origin.clone().add(pos[0], 0, pos[1]);
+                Block block = world.getBlockAt(farmLoc);
+
+                // Place a sign block instead of farm block for locked farms
+                block.setType(Material.OAK_SIGN);
+
+                // Set sign text
+                if (block.getState() instanceof Sign sign) {
+                    sign.setLine(0, ChatColor.DARK_RED + "§l[LOCKED]");
+                    sign.setLine(1, ChatColor.GOLD + farmType.getDisplayName());
+                    sign.setLine(2, ChatColor.YELLOW + "Right-click");
+                    sign.setLine(3, ChatColor.YELLOW + "to unlock");
+                    sign.update();
+                }
+            }
+        }
+    }
+
+    /**
+     * Update farm block when unlocked
+     */
+    public void unlockFarmType(UUID playerUuid, FarmType farmType) {
+        PlantationArea area = areas.get(playerUuid);
+        if (area == null) return;
+
+        List<int[]> positions = FARM_LAYOUT.get(farmType);
+        if (positions != null && !positions.isEmpty()) {
+            // Replace sign with actual farm block for first instance
+            int[] pos = positions.get(0);
+            Location farmLoc = area.origin.clone().add(pos[0], 0, pos[1]);
+            Block block = world.getBlockAt(farmLoc);
+            block.setType(farmType.getBlockType());
+        }
+    }
+
     public Location getOrCreateFarmAnchor(UUID owner, FarmType type, int instanceId) {
         PlantationArea area = areas.get(owner);
         if (area == null) {
@@ -201,38 +246,39 @@ public class PlantationAreaManager {
                 return null;
             }
         }
-        
+
         FarmAnchor anchor = area.getFarmAnchor(type, instanceId);
         if (anchor != null) {
             return anchor.location;
         }
-        
+
         // Create new anchor
         List<int[]> positions = FARM_LAYOUT.get(type);
         if (positions == null || instanceId > positions.size() || instanceId < 1) {
             return null;
         }
-        
+
         int[] pos = positions.get(instanceId - 1);
         Location anchorLoc = area.origin.clone().add(pos[0], 0, pos[1]);
-        
-        // Place the anchor block
+
+        // Place the farm block
         if (world != null) {
             Block block = world.getBlockAt(anchorLoc);
-            block.setType(type.getBlockType());
+            // Only place if it's unlocked or Berry Orchards
+            if (type == FarmType.BERRY_ORCHARDS ||
+                plugin.getDatabaseManager().isFarmUnlocked(owner, type.getId())) {
+                block.setType(type.getBlockType());
+            }
         }
-        
+
         // Save anchor to area and database
         FarmAnchor newAnchor = new FarmAnchor(anchorLoc, type, instanceId);
         area.addFarmAnchor(type, instanceId, newAnchor);
         saveFarmAnchor(owner, type, instanceId, anchorLoc);
-        
+
         return anchorLoc;
     }
 
-    /**
-     * Save farm anchor to database
-     */
     private void saveFarmAnchor(UUID uuid, FarmType type, int instanceId, Location loc) {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
@@ -265,28 +311,22 @@ public class PlantationAreaManager {
         return loc;
     }
 
-    /**
-     * Build the plot structure with decorative elements and proper floor
-     */
     private void buildPlotStructure(Location origin) {
         if (world == null) return;
-        
+
         int x1 = origin.getBlockX();
         int z1 = origin.getBlockZ();
         int x2 = x1 + plotWidth - 1;
         int z2 = z1 + plotDepth - 1;
         int y = origin.getBlockY();
 
-        // FIRST: Create the floor - this is critical!
+        // Create the floor
         for (int x = x1; x <= x2; x++) {
             for (int z = z1; z <= z2; z++) {
-                // Create solid ground
                 world.getBlockAt(x, y - 1, z).setType(Material.GRASS_BLOCK);
-                // Add dirt layers below for safety
                 world.getBlockAt(x, y - 2, z).setType(Material.DIRT);
                 world.getBlockAt(x, y - 3, z).setType(Material.STONE);
-                
-                // Clear space above
+
                 world.getBlockAt(x, y, z).setType(Material.AIR);
                 world.getBlockAt(x, y + 1, z).setType(Material.AIR);
                 world.getBlockAt(x, y + 2, z).setType(Material.AIR);
@@ -302,103 +342,72 @@ public class PlantationAreaManager {
             world.getBlockAt(x1, y, z).setType(fenceMaterial);
             world.getBlockAt(x2, y, z).setType(fenceMaterial);
         }
-        
+
         // Add gate at front center
         int gateX = x1 + plotWidth / 2;
         world.getBlockAt(gateX, y, z1).setType(gateMaterial);
-        
-        // Add decorative path from gate to center
+
+        // Add decorative path
         for (int z = z1 + 1; z < z1 + 4; z++) {
             world.getBlockAt(gateX, y - 1, z).setType(Material.DIRT_PATH);
-            // Also add path on sides
-            if (gateX - 1 >= x1) {
-                world.getBlockAt(gateX - 1, y - 1, z).setType(Material.COARSE_DIRT);
-            }
-            if (gateX + 1 <= x2) {
-                world.getBlockAt(gateX + 1, y - 1, z).setType(Material.COARSE_DIRT);
-            }
         }
-        
-        // Add some lanterns for ambiance
+
+        // Add lanterns
         world.getBlockAt(gateX - 1, y + 1, z1).setType(Material.LANTERN);
         world.getBlockAt(gateX + 1, y + 1, z1).setType(Material.LANTERN);
-        
-        // Add corner posts with lanterns
         world.getBlockAt(x1, y + 1, z1).setType(Material.LANTERN);
         world.getBlockAt(x2, y + 1, z1).setType(Material.LANTERN);
         world.getBlockAt(x1, y + 1, z2).setType(Material.LANTERN);
         world.getBlockAt(x2, y + 1, z2).setType(Material.LANTERN);
-        
-        // Add some decorative elements (flowers, tall grass)
-        Random random = new Random();
-        for (int i = 0; i < 8; i++) {
-            int randX = x1 + 1 + random.nextInt(plotWidth - 2);
-            int randZ = z1 + 1 + random.nextInt(plotDepth - 2);
-            
-            // Make sure we don't place on the path
-            if (Math.abs(randX - gateX) <= 1 && randZ <= z1 + 3) {
-                continue;
-            }
-            
-            Block decorBlock = world.getBlockAt(randX, y, randZ);
-            if (decorBlock.getType() == Material.AIR) {
-                Material shortGrass = Material.matchMaterial("SHORT_GRASS");
-                Material[] decorations = shortGrass != null
-                        ? new Material[]{Material.DANDELION, Material.POPPY, shortGrass, Material.TALL_GRASS}
-                        : new Material[]{Material.DANDELION, Material.POPPY, Material.TALL_GRASS};
-                decorBlock.setType(decorations[random.nextInt(decorations.length)]);
-            }
-        }
     }
 
-    /**
-     * Check if location is within player's plantation
-     */
     public boolean isLocationInPlantation(UUID owner, Location loc) {
         PlantationArea area = areas.get(owner);
         return area != null && area.contains(loc);
     }
 
-    /**
-     * Get farm instance from location
-     */
     public int getFarmInstanceFromLocation(UUID owner, FarmType type, Location loc) {
         PlantationArea area = areas.get(owner);
         if (area == null) return -1;
-        
-        FarmAnchor anchor = area.getFarmAnchorByLocation(loc);
-        return anchor != null ? anchor.instanceId : -1;
+
+        // Check all possible positions for this farm type
+        List<int[]> positions = FARM_LAYOUT.get(type);
+        if (positions != null) {
+            for (int i = 0; i < positions.size(); i++) {
+                int[] pos = positions.get(i);
+                Location farmLoc = area.origin.clone().add(pos[0], 0, pos[1]);
+
+                if (farmLoc.getBlockX() == loc.getBlockX() &&
+                    farmLoc.getBlockY() == loc.getBlockY() &&
+                    farmLoc.getBlockZ() == loc.getBlockZ()) {
+                    return i + 1; // Instance IDs start at 1
+                }
+            }
+        }
+
+        return -1;
     }
 
-    /**
-     * Get the maximum allowed instances for a farm type
-     */
     public int getMaxInstances(FarmType type) {
         List<int[]> positions = FARM_LAYOUT.get(type);
         return positions != null ? positions.size() : 0;
     }
 
-    /**
-     * Check if a specific instance slot is available
-     */
     public boolean isInstanceAvailable(UUID owner, FarmType type, int instanceId) {
         if (instanceId < 1 || instanceId > getMaxInstances(type)) {
             return false;
         }
-        
+
         PlantationArea area = areas.get(owner);
         if (area == null) return true;
-        
+
         return area.getFarmAnchor(type, instanceId) == null;
     }
 
-    /**
-     * Get all farm anchors for a player
-     */
     public Map<FarmType, Map<Integer, Location>> getAllFarmAnchors(UUID owner) {
         PlantationArea area = areas.get(owner);
         if (area == null) return new EnumMap<>(FarmType.class);
-        
+
         Map<FarmType, Map<Integer, Location>> result = new EnumMap<>(FarmType.class);
         for (Map.Entry<FarmType, Map<Integer, FarmAnchor>> typeEntry : area.anchors.entrySet()) {
             Map<Integer, Location> locations = new HashMap<>();
@@ -411,8 +420,37 @@ public class PlantationAreaManager {
     }
 
     /**
-     * Represents a single player's plantation plot
+     * Check if a location is a farm sign (for unlocking)
      */
+    public boolean isFarmSign(Location loc) {
+        Block block = loc.getBlock();
+        return block.getState() instanceof Sign;
+    }
+
+    /**
+     * Get farm type from sign location
+     */
+    public FarmType getFarmTypeFromSign(Location loc) {
+        for (PlantationArea area : areas.values()) {
+            for (FarmType type : FarmType.values()) {
+                if (type == FarmType.BERRY_ORCHARDS) continue;
+
+                List<int[]> positions = FARM_LAYOUT.get(type);
+                if (positions != null && !positions.isEmpty()) {
+                    int[] pos = positions.get(0);
+                    Location signLoc = area.origin.clone().add(pos[0], 0, pos[1]);
+
+                    if (signLoc.getBlockX() == loc.getBlockX() &&
+                        signLoc.getBlockY() == loc.getBlockY() &&
+                        signLoc.getBlockZ() == loc.getBlockZ()) {
+                        return type;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     public static class PlantationArea {
         private final UUID owner;
         private final Location origin;
@@ -420,7 +458,7 @@ public class PlantationAreaManager {
         private final int width;
         private final int depth;
 
-        PlantationArea(UUID owner, Location origin, Map<FarmType, Map<Integer, FarmAnchor>> anchors, 
+        PlantationArea(UUID owner, Location origin, Map<FarmType, Map<Integer, FarmAnchor>> anchors,
                       int width, int depth) {
             this.owner = owner;
             this.origin = origin;
@@ -434,38 +472,24 @@ public class PlantationAreaManager {
         }
 
         public Location getSpawnPoint() {
-            // Spawn point near the gate, raised by 1 block for safety
             return origin.clone().add(width / 2.0, 1, 2);
         }
 
         boolean contains(Location loc) {
             if (loc == null || origin.getWorld() == null) return false;
             if (!loc.getWorld().equals(origin.getWorld())) return false;
-            
+
             int x = loc.getBlockX();
             int z = loc.getBlockZ();
             int x1 = origin.getBlockX();
             int z1 = origin.getBlockZ();
-            
+
             return x >= x1 && x < x1 + width && z >= z1 && z < z1 + depth;
         }
 
         FarmAnchor getFarmAnchor(FarmType type, int instanceId) {
             Map<Integer, FarmAnchor> typeAnchors = anchors.get(type);
             return typeAnchors != null ? typeAnchors.get(instanceId) : null;
-        }
-
-        FarmAnchor getFarmAnchorByLocation(Location loc) {
-            for (Map<Integer, FarmAnchor> typeAnchors : anchors.values()) {
-                for (FarmAnchor anchor : typeAnchors.values()) {
-                    if (anchor.location.getBlockX() == loc.getBlockX() &&
-                        anchor.location.getBlockY() == loc.getBlockY() &&
-                        anchor.location.getBlockZ() == loc.getBlockZ()) {
-                        return anchor;
-                    }
-                }
-            }
-            return null;
         }
 
         void addFarmAnchor(FarmType type, int instanceId, FarmAnchor anchor) {
@@ -481,9 +505,6 @@ public class PlantationAreaManager {
         }
     }
 
-    /**
-     * Represents a farm anchor point
-     */
     private static class FarmAnchor {
         final Location location;
         final FarmType type;
@@ -496,3 +517,4 @@ public class PlantationAreaManager {
         }
     }
 }
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,16 +1,55 @@
-# FarmingPlugin Configuration
-# MMO RPG Farming System
+# Farming Plugin Configuration
 
 # Database settings
 database:
   host: localhost
   port: 3306
-  # "name" and "user" keys are also accepted for compatibility
   name: plantation
   user: root
   password: ""
 
-# Plantation world and layout settings
+# Economy settings
+economy:
+  enabled: true
+  
+# Fruit prices (in-game currency)
+fruits:
+  sweet_berries:
+    display_name: "&dSweet Berries"
+    sell_price: 50000
+  golden_melon:
+    display_name: "&6Golden Melon Slice"
+    sell_price: 75000
+  mystic_mushroom:
+    display_name: "&5Mystic Mushroom"
+    sell_price: 100000
+  enchanted_pumpkin:
+    display_name: "&6Enchanted Pumpkin Slice"
+    sell_price: 125000
+  ethereal_flower:
+    display_name: "&dEthereal Blossom"
+    sell_price: 200000
+  ancient_seed:
+    display_name: "&2Ancient Mangrove Seed"
+    sell_price: 350000
+  desert_date:
+    display_name: "&eDesert Golden Date"
+    sell_price: 500000
+
+# Teleportation settings
+teleport:
+  require_level: true
+  minimum_level: 85
+  cooldown_seconds: 5
+  require_permission: true
+  permission: "plantation.use"
+  
+# NPC Integration (for Citizens/NPCMD)
+npc:
+  enabled: true
+  temporary_permission_command: "npcmd add plantation.use plantation"
+  
+# Plantation settings
 plantations:
   world: world
   base:
@@ -20,43 +59,41 @@ plantations:
       z: 0
     plot:
       width: 16
-      height: 16
       depth: 16
       fence_material: OAK_FENCE
       gate_material: OAK_FENCE_GATE
-    spacing: 5
+    spacing: 20
     grid:
       rows: 10
       cols: 10
-  
+      
   # Protection settings
   protection:
     block_build: true
     block_pvp: false
-  
+    
   # Hologram settings
   holograms:
     enabled: true
-    title: "&e{farm_display}"
-    ready: "&a&lREADY! &7Right-click to collect"
-    running: "&7Next: &a{time_left}"
-  
-  # Drop settings
-  drop:
-    radius: 0.6
+    update_interval: 30 # seconds
 
-# Starter kit for new players
+# Starter kit - disable by default
 starter_kit:
-  enabled: true
+  enabled: false
+  items:
+    - material: PLANT_FIBER
+      tier: 1
+      amount: 10
 
 # Auto-save settings
 auto_save:
   enabled: true
   interval_minutes: 5
 
+# Debug mode
+debug: false
+
 # Metrics
 metrics:
   enabled: true
 
-# Debug mode
-debug: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,36 +1,56 @@
 name: FarmingPlugin
-version: 1.0.0
 main: org.maks.farmingPlugin.FarmingPlugin
+version: 1.0
 api-version: 1.20
-author: Maks
-description: MMO RPG Farming System with fruits and rare materials
-softdepend: [Vault]
+author: maks
+description: Advanced farming system with plantations
+
+depend:
+  - Vault
 
 commands:
   plantation:
     description: Main plantation command
-    usage: /<command> [subcommand]
-    aliases: [farm, plant, p]
-    permission: plantation.access
-    permission-message: You don't have permission to use plantations!
+    usage: /plantation [tp|info|stats|settings|help]
+    aliases: [farm, farms, plant]
 
 permissions:
-  plantation.*:
-    description: All plantation permissions
+  plantation.use:
+    description: Allows using plantation system
+    default: false
+
+  plantation.admin:
+    description: Admin commands for plantations
     default: op
     children:
-      plantation.access: true
-      plantation.admin: true
       plantation.admin.build: true
-  
-  plantation.access:
-    description: Basic access to plantation features
-    default: true
-  
-  plantation.admin:
-    description: Admin commands and features
-    default: op
-  
+      plantation.admin.reload: true
+      plantation.admin.reset: true
+      plantation.admin.give: true
+      plantation.admin.setlevel: true
+      plantation.admin.debug: true
+
   plantation.admin.build:
     description: Build on other players' plantations
     default: op
+
+  plantation.admin.reload:
+    description: Reload plugin configuration
+    default: op
+
+  plantation.admin.reset:
+    description: Reset player plantations
+    default: op
+
+  plantation.admin.give:
+    description: Give materials to players
+    default: op
+
+  plantation.admin.setlevel:
+    description: Set farm levels
+    default: op
+
+  plantation.admin.debug:
+    description: Use debug commands
+    default: op
+


### PR DESCRIPTION
## Summary
- Load fruit names and sell values from configuration and generate custom item stacks
- Add portal-style teleport GUI with level gating and player stats
- Auto-place berry bushes and locked farm signs when allocating plantations
- Streamline join messaging and inventory listeners for the new teleport menu
- Initialize fruit types during plugin startup

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad92a280b8832a84fa9efa6c65636c