### PR TITLE
Pre-spawn farm anchors and restrict interactions

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
@@ -10,7 +10,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.maks.farmingPlugin.FarmingPlugin;
 import org.maks.farmingPlugin.farms.FarmInstance;
 import org.maks.farmingPlugin.farms.FarmType;
-import org.maks.farmingPlugin.fruits.FruitType;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,19 +68,8 @@ public class HologramManager {
     private List<String> generateHologramLines(FarmInstance farm) {
         List<String> lines = new ArrayList<>();
         
-        // Farm title with fruit info
-        FruitType fruitType = FruitType.getForFarm(farm.getFarmType());
-        String title = ChatColor.YELLOW + farm.getFarmType().getDisplayName();
-        lines.add(title);
-        
-        // Instance and level info
-        lines.add(ChatColor.GRAY + "Instance #" + farm.getInstanceId() + 
-                 " | Level " + farm.getLevel());
-        
-        // Fruit production info
-        if (fruitType != null) {
-            lines.add(ChatColor.GREEN + "Produces: " + fruitType.getDisplayName());
-        }
+        // Farm title only
+        lines.add(ChatColor.YELLOW + farm.getFarmType().getDisplayName());
         
         // Growth status
         if (farm.isReadyForHarvest()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -71,19 +71,13 @@ plantations:
   protection:
     block_build: true
     block_pvp: false
+    block_farm_blocks: true
     
   # Hologram settings
   holograms:
     enabled: true
     update_interval: 30 # seconds
 
-# Starter kit - disable by default
-starter_kit:
-  enabled: false
-  items:
-    - material: PLANT_FIBER
-      tier: 1
-      amount: 10
 
 # Auto-save settings
 auto_save:


### PR DESCRIPTION
## Summary
- Pre-create farm anchors for all farm slots and ensure blocks are set for each type
- Limit farm interactions to designated anchor blocks and block manual placement of farm blocks
- Simplify holograms to show only farm name, growth status, and efficiency
- Remove starter kit logic and add configuration to block farm block placement

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adba581cd8832ab96cf35fdfefcd0b