### PR TITLE
Add plantation layout regeneration with locked signs and test mode

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/farms/FarmInstance.java
+++ b/src/main/java/org/maks/farmingPlugin/farms/FarmInstance.java
@@ -1,6 +1,7 @@
 package org.maks.farmingPlugin.farms;
 
 import org.bukkit.Location;
+import org.maks.farmingPlugin.FarmingPlugin;
 import org.maks.farmingPlugin.materials.MaterialType;
 
 import java.util.HashMap;
@@ -161,10 +162,10 @@ public class FarmInstance {
      * Get adjusted growth time considering all modifiers
      */
     public long getAdjustedGrowthTime() {
-        long baseTime = farmType.getGrowthTimeMillis();
+        long baseTime = FarmingPlugin.getInstance().getPlantationManager().getHarvestIntervalMillis(this);
         double efficiencyModifier = 1.0 / getEfficiency();
         double levelModifier = 1.0 - (level - 1) * 0.05; // -5% per level
-        
+
         return (long) (baseTime * efficiencyModifier * levelModifier);
     }
 

--- a/src/main/java/org/maks/farmingPlugin/farms/FarmType.java
+++ b/src/main/java/org/maks/farmingPlugin/farms/FarmType.java
@@ -21,8 +21,9 @@ public enum FarmType {
     private final int maxInstances;
     private final int growthTimeHours;
     private final int storageLimit;
+    private final int harvestSeconds;
 
-    FarmType(String id, String displayName, Material blockType, long unlockCost, 
+    FarmType(String id, String displayName, Material blockType, long unlockCost,
              int maxInstances, int growthTimeHours, int storageLimit) {
         this.id = id;
         this.displayName = displayName;
@@ -31,6 +32,7 @@ public enum FarmType {
         this.maxInstances = maxInstances;
         this.growthTimeHours = growthTimeHours;
         this.storageLimit = storageLimit;
+        this.harvestSeconds = growthTimeHours * 3600;
     }
 
     public String getId() {
@@ -63,6 +65,10 @@ public enum FarmType {
 
     public int getStorageLimit() {
         return storageLimit;
+    }
+
+    public int getHarvestSeconds() {
+        return harvestSeconds;
     }
 
     public static FarmType fromId(String id) {

--- a/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
@@ -24,12 +24,14 @@ public class HologramManager {
     private final Map<String, List<ArmorStand>> holograms = new ConcurrentHashMap<>();
     private final Map<String, Long> lastUpdateTimes = new ConcurrentHashMap<>();
     private final boolean enabled;
+    private final double yOffset;
     private BukkitRunnable updateTask;
     private static final long UPDATE_COOLDOWN = 5000; // 5 seconds minimum between updates
 
     public HologramManager(FarmingPlugin plugin) {
         this.plugin = plugin;
         this.enabled = plugin.getConfig().getBoolean("plantations.holograms.enabled", true);
+        this.yOffset = plugin.getConfig().getDouble("plantation.holograms.y_offset", -0.6);
         
         if (enabled) {
             startUpdateTask();
@@ -56,10 +58,14 @@ public class HologramManager {
         
         // Create new hologram lines
         List<String> lines = generateHologramLines(farm);
-        Location baseLocation = farm.getLocation().clone().add(0.5, 2.5, 0.5);
-        
+        Location baseLocation = holoLoc(farm.getLocation());
+
         createHologram(hologramKey, baseLocation, lines);
         lastUpdateTimes.put(hologramKey, System.currentTimeMillis());
+    }
+
+    private Location holoLoc(Location base) {
+        return base.clone().add(0.5, yOffset, 0.5);
     }
 
     /**
@@ -239,7 +245,7 @@ public class HologramManager {
         if (!enabled) return;
         
         ArmorStand stand = (ArmorStand) location.getWorld().spawnEntity(
-            location.clone().add(0.5, 1, 0.5), EntityType.ARMOR_STAND);
+            holoLoc(location), EntityType.ARMOR_STAND);
         
         stand.setVisible(false);
         stand.setGravity(false);

--- a/src/main/java/org/maks/farmingPlugin/managers/OfflineGrowthManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/OfflineGrowthManager.java
@@ -54,7 +54,7 @@ public class OfflineGrowthManager {
 
         long currentTime = System.currentTimeMillis();
         long lastHarvest = farm.getLastHarvest();
-        long growthTime = farm.getFarmType().getGrowthTimeMillis() / farm.getEfficiency();
+        long growthTime = plantationManager.getHarvestIntervalMillis(farm) / farm.getEfficiency();
         
         long timeSinceHarvest = currentTime - lastHarvest;
         

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -91,3 +91,24 @@ debug: false
 metrics:
   enabled: true
 
+# --- PLANTATION LAYOUT & WORLD ---
+plantation:
+  world: world
+  spawn:
+    x: 1008
+    y: 64
+    z: 998
+  holograms:
+    y_offset: -0.6
+  rebuild_on_join: true
+
+# --- TRYB TESTOWY ---
+test_mode:
+  enabled: true
+  growth_minutes: 1
+
+# (opcjonalnie) materiały pod uprawy/ścieżki
+blocks:
+  path: DIRT_PATH
+  ground: GRASS_BLOCK
+


### PR DESCRIPTION
## Summary
- regenerate player plantation area from config coordinates and place LOCKED signs for unowned farms
- allow unlocking farms by right-clicking signs and rebuild area on join
- add hologram Y-offset and test-mode growth overrides

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adcc848990832a92b58b0fb9602a81