### PR TITLE
Translate player messages to English and add test mode logging

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/FarmingPlugin.java
+++ b/src/main/java/org/maks/farmingPlugin/FarmingPlugin.java
@@ -52,10 +52,14 @@ public final class FarmingPlugin extends JavaPlugin {
                 startMetrics();
             }
             
-            getLogger().info("═══════════════════════════════════════");
+            getLogger().info("╔════════════════════════════════════╗");
             getLogger().info("    Farming Plugin - Ready!");
             getLogger().info("    " + getServer().getOnlinePlayers().size() + " players loaded");
-            getLogger().info("═══════════════════════════════════════");
+            if (getConfig().getBoolean("test_mode.enabled", false)) {
+                getLogger().warning("    TEST MODE ENABLED - Farms grow in " +
+                                  getConfig().getInt("test_mode.growth_minutes", 1) + " minute(s)!");
+            }
+            getLogger().info("╚════════════════════════════════════╝");
             
         } catch (Exception e) {
             getLogger().log(Level.SEVERE, "Failed to initialize plugin!", e);

--- a/src/main/java/org/maks/farmingPlugin/listeners/PlantationListeners.java
+++ b/src/main/java/org/maks/farmingPlugin/listeners/PlantationListeners.java
@@ -137,7 +137,7 @@ public class PlantationListeners implements Listener {
             .getFarmInstanceFromLocation(player.getUniqueId(), farmType, block.getLocation());
 
         if (instanceId == -1) {
-            player.sendMessage(ChatColor.RED + "Użyj jednego z oznaczonych miejsc dla: "
+            player.sendMessage(ChatColor.RED + "Please use one of the marked spots for "
                                + farmType.getDisplayName() + ".");
             player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, 1.0f, 0.8f);
             return;
@@ -225,7 +225,7 @@ public class PlantationListeners implements Listener {
             }, 2L);
             player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
         } else {
-            player.sendMessage(ChatColor.RED + "Brakuje wymagań żeby odblokować tę farmę.");
+            player.sendMessage(ChatColor.RED + "You don't meet the requirements to unlock this farm.");
             player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1f, 0.8f);
         }
     }
@@ -458,9 +458,9 @@ public class PlantationListeners implements Listener {
                 if (owner != null) {
                     event.setCancelled(true);
                     if (owner.equals(player.getUniqueId())) {
-                        player.sendMessage(ChatColor.RED + "Nie możesz ręcznie stawiać bloków farm. Korzystaj z oznaczonych slotów.");
+                        player.sendMessage(ChatColor.RED + "You cannot manually place farm blocks. Use the designated slots.");
                     } else {
-                        player.sendMessage(ChatColor.RED + "Nie możesz budować na cudzej plantacji!");
+                        player.sendMessage(ChatColor.RED + "You cannot build on another player's plantation!");
                     }
                 }
             }

--- a/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
@@ -31,7 +31,7 @@ public class HologramManager {
     public HologramManager(FarmingPlugin plugin) {
         this.plugin = plugin;
         this.enabled = plugin.getConfig().getBoolean("plantations.holograms.enabled", true);
-        this.yOffset = plugin.getConfig().getDouble("plantation.holograms.y_offset", -0.6);
+        this.yOffset = plugin.getConfig().getDouble("plantation.holograms.y_offset", 2.0);
         
         if (enabled) {
             startUpdateTask();

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -7,9 +7,6 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.Directional;
-import org.bukkit.block.data.Rotatable;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -25,8 +22,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.UUID;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,62 +29,73 @@ public class PlantationAreaManager {
 
     private final FarmingPlugin plugin;
     private final Map<UUID, PlantationArea> areas = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<FarmType, Map<Integer, FarmAnchor>>> playerAnchors = new ConcurrentHashMap<>();
 
     private final World world;
     private final int originX, originY, originZ;
-    private final int plotWidth, plotDepth, spacing, gridRows, gridCols;
+    private final int plotWidth = 17;
+    private final int plotDepth = 15;
+    private final int spacing;
+    private final int gridRows, gridCols;
     private final Material fenceMaterial, gateMaterial;
 
-    private NamespacedKey PDC_LOCKED = new NamespacedKey(FarmingPlugin.getInstance(), "locked_farm");
-    private NamespacedKey PDC_FARM_TYPE = new NamespacedKey(FarmingPlugin.getInstance(), "farm_type");
-    private NamespacedKey PDC_INSTANCE_ID = new NamespacedKey(FarmingPlugin.getInstance(), "instance_id");
+    private NamespacedKey PDC_LOCKED;
+    private NamespacedKey PDC_FARM_TYPE;
+    private NamespacedKey PDC_INSTANCE_ID;
 
-    // Farm layout configuration - positions for different farm types and instances
+    // Relative positions for farms within each player's plot
+    // These are OFFSETS from the player's plot origin
     private static final Map<FarmType, List<int[]>> FARM_LAYOUT = new HashMap<>();
 
     static {
-        // Berry Orchards - 6 instances (most common, front area)
+        // Berry Orchards - 6 instances (right side)
+        // Relative positions in a 2x3 grid
         FARM_LAYOUT.put(FarmType.BERRY_ORCHARDS, Arrays.asList(
-            new int[]{2, 2}, new int[]{4, 2}, new int[]{6, 2},
-            new int[]{2, 4}, new int[]{4, 4}, new int[]{6, 4}
+            new int[]{10, 13}, new int[]{12, 13}, new int[]{14, 13}, // Top row (near spawn)
+            new int[]{10, 11}, new int[]{12, 11}, new int[]{14, 11}  // Bottom row
         ));
 
-        // Melon Groves - 6 instances (second row)
+        // Melon Groves - 6 instances (left side)
         FARM_LAYOUT.put(FarmType.MELON_GROVES, Arrays.asList(
-            new int[]{8, 2}, new int[]{10, 2}, new int[]{8, 4},
-            new int[]{10, 4}, new int[]{8, 6}, new int[]{10, 6}
+            new int[]{2, 13}, new int[]{4, 13}, new int[]{6, 13},    // Top row
+            new int[]{2, 11}, new int[]{4, 11}, new int[]{6, 11}     // Bottom row
         ));
 
-        // Fungal Caverns - 6 instances (third area)
+        // Fungal Caverns - 6 instances (right side, middle)
         FARM_LAYOUT.put(FarmType.FUNGAL_CAVERNS, Arrays.asList(
-            new int[]{2, 6}, new int[]{4, 6}, new int[]{6, 6},
-            new int[]{2, 8}, new int[]{4, 8}, new int[]{6, 8}
+            new int[]{10, 9}, new int[]{12, 9}, new int[]{14, 9},    // Top row
+            new int[]{10, 7}, new int[]{12, 7}, new int[]{14, 7}     // Bottom row
         ));
 
-        // Pumpkin Patches - 6 instances
+        // Pumpkin Patches - 6 instances (left side, middle)
         FARM_LAYOUT.put(FarmType.PUMPKIN_PATCHES, Arrays.asList(
-            new int[]{8, 8}, new int[]{10, 8}, new int[]{8, 10},
-            new int[]{10, 10}, new int[]{7, 9}, new int[]{9, 9}
+            new int[]{2, 9}, new int[]{4, 9}, new int[]{6, 9},       // Top row
+            new int[]{2, 7}, new int[]{4, 7}, new int[]{6, 7}        // Bottom row
         ));
 
-        // Mystic Gardens - 3 instances (rare, special area)
+        // Mystic Gardens - 3 instances (right side, bottom)
         FARM_LAYOUT.put(FarmType.MYSTIC_GARDENS, Arrays.asList(
-            new int[]{3, 10}, new int[]{5, 10}, new int[]{4, 11}
+            new int[]{10, 5}, new int[]{12, 5}, new int[]{14, 5}
         ));
 
-        // Ancient Mangroves - 3 instances (very rare)
+        // Ancient Mangroves - 3 instances (left side, bottom)
         FARM_LAYOUT.put(FarmType.ANCIENT_MANGROVES, Arrays.asList(
-            new int[]{2, 11}, new int[]{6, 11}, new int[]{4, 12}
+            new int[]{2, 5}, new int[]{4, 5}, new int[]{6, 5}
         ));
 
-        // Desert Sanctuaries - 1 instance (legendary, center-back)
+        // Desert Sanctuaries - 1 instance (center, very bottom)
         FARM_LAYOUT.put(FarmType.DESERT_SANCTUARIES, Arrays.asList(
-            new int[]{6, 9}
+            new int[]{8, 3}
         ));
     }
 
     public PlantationAreaManager(FarmingPlugin plugin) {
         this.plugin = plugin;
+
+        // Initialize PDC keys
+        this.PDC_LOCKED = new NamespacedKey(plugin, "locked_farm");
+        this.PDC_FARM_TYPE = new NamespacedKey(plugin, "farm_type");
+        this.PDC_INSTANCE_ID = new NamespacedKey(plugin, "instance_id");
 
         ConfigurationSection base = plugin.getConfig().getConfigurationSection("plantations.base");
         this.world = Bukkit.getWorld(plugin.getConfig().getString("plantations.world", "world"));
@@ -100,8 +106,6 @@ public class PlantationAreaManager {
         this.originZ = originSec.getInt("z");
 
         ConfigurationSection plotSec = base.getConfigurationSection("plot");
-        this.plotWidth = plotSec.getInt("width", 16);
-        this.plotDepth = plotSec.getInt("depth", 16);
         this.fenceMaterial = Material.valueOf(plotSec.getString("fence_material", "OAK_FENCE"));
         this.gateMaterial = Material.valueOf(plotSec.getString("gate_material", "OAK_FENCE_GATE"));
 
@@ -140,44 +144,8 @@ public class PlantationAreaManager {
         Optional<Location> savedLocation = plugin.getDatabaseManager().loadPlayerPlot(uuid);
         if (savedLocation.isPresent()) {
             Location origin = savedLocation.get();
-            Map<FarmType, Map<Integer, FarmAnchor>> anchors = loadFarmAnchors(uuid, origin);
-            areas.put(uuid, new PlantationArea(uuid, origin, anchors, plotWidth, plotDepth));
+            areas.put(uuid, new PlantationArea(uuid, origin, plotWidth, plotDepth));
         }
-    }
-
-    private Map<FarmType, Map<Integer, FarmAnchor>> loadFarmAnchors(UUID uuid, Location origin) {
-        Map<FarmType, Map<Integer, FarmAnchor>> anchors = new EnumMap<>(FarmType.class);
-
-        try {
-            String sql = "SELECT farm_type, instance_id, anchor_x, anchor_y, anchor_z FROM farming_farm_anchors WHERE uuid = ?";
-            PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);
-            stmt.setString(1, uuid.toString());
-            ResultSet rs = stmt.executeQuery();
-
-            while (rs.next()) {
-                FarmType type = FarmType.fromId(rs.getString("farm_type"));
-                int instanceId = rs.getInt("instance_id");
-
-                if (type != null) {
-                    Location anchorLoc = new Location(
-                        world,
-                        rs.getInt("anchor_x"),
-                        rs.getInt("anchor_y"),
-                        rs.getInt("anchor_z")
-                    );
-
-                    anchors.computeIfAbsent(type, k -> new HashMap<>())
-                           .put(instanceId, new FarmAnchor(anchorLoc, type, instanceId));
-                }
-            }
-
-            rs.close();
-            stmt.close();
-        } catch (SQLException e) {
-            plugin.getLogger().warning("Failed to load farm anchors: " + e.getMessage());
-        }
-
-        return anchors;
     }
 
     public PlantationArea getOrCreateArea(Player player) {
@@ -185,82 +153,9 @@ public class PlantationAreaManager {
             DatabaseManager db = plugin.getDatabaseManager();
             Location origin = db.loadPlayerPlot(uuid).orElseGet(() -> allocateNewPlot(uuid));
             buildPlotStructure(origin);
-            Map<FarmType, Map<Integer, FarmAnchor>> anchors = new EnumMap<>(FarmType.class);
-            return new PlantationArea(uuid, origin, anchors, plotWidth, plotDepth);
+            return new PlantationArea(uuid, origin, plotWidth, plotDepth);
         });
-        ensureAllAnchors(player.getUniqueId());
         return area;
-    }
-
-    public void ensureAllAnchors(UUID owner) {
-        for (FarmType type : FarmType.values()) {
-            for (int i = 1; i <= type.getMaxInstances(); i++) {
-                getOrCreateFarmAnchor(owner, type, i);
-            }
-        }
-    }
-
-    public Location getOrCreateFarmAnchor(UUID owner, FarmType type, int instanceId) {
-        PlantationArea area = areas.get(owner);
-        if (area == null) {
-            Player player = Bukkit.getPlayer(owner);
-            if (player != null) {
-                area = getOrCreateArea(player);
-            } else {
-                return null;
-            }
-        }
-
-        FarmAnchor anchor = area.getFarmAnchor(type, instanceId);
-        if (anchor != null) {
-            if (world != null) {
-                world.getBlockAt(anchor.location).setType(type.getBlockType());
-            }
-            return anchor.location;
-        }
-
-        // Create new anchor
-        List<int[]> positions = FARM_LAYOUT.get(type);
-        if (positions == null || instanceId > positions.size() || instanceId < 1) {
-            return null;
-        }
-
-        int[] pos = positions.get(instanceId - 1);
-        Location anchorLoc = area.origin.clone().add(pos[0], 0, pos[1]);
-
-        // Place the farm block
-        if (world != null) {
-            Block block = world.getBlockAt(anchorLoc);
-            block.setType(type.getBlockType());
-        }
-
-        // Save anchor to area and database
-        FarmAnchor newAnchor = new FarmAnchor(anchorLoc, type, instanceId);
-        area.addFarmAnchor(type, instanceId, newAnchor);
-        saveFarmAnchor(owner, type, instanceId, anchorLoc);
-
-        return anchorLoc;
-    }
-
-    private void saveFarmAnchor(UUID uuid, FarmType type, int instanceId, Location loc) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                String sql = "INSERT INTO farming_farm_anchors (uuid, farm_type, instance_id, anchor_x, anchor_y, anchor_z) " +
-                           "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE " +
-                           "anchor_x = VALUES(anchor_x), anchor_y = VALUES(anchor_y), anchor_z = VALUES(anchor_z)";
-                PreparedStatement stmt = plugin.getDatabaseManager().prepareStatement(sql);
-                stmt.setString(1, uuid.toString());
-                stmt.setString(2, type.getId());
-                stmt.setInt(3, instanceId);
-                stmt.setInt(4, loc.getBlockX());
-                stmt.setInt(5, loc.getBlockY());
-                stmt.setInt(6, loc.getBlockZ());
-                stmt.executeUpdate();
-                stmt.close();
-            } catch (SQLException e) {
-                plugin.getLogger().warning("Failed to save farm anchor: " + e.getMessage());
-            }
-        });
     }
 
     private Location allocateNewPlot(UUID uuid) {
@@ -270,7 +165,10 @@ public class PlantationAreaManager {
         int x = originX + col * (plotWidth + spacing);
         int z = originZ + row * (plotDepth + spacing);
         Location loc = new Location(world, x, originY, z);
+        
+        plugin.getLogger().info("Allocating new plot for " + uuid + " at coordinates: " + x + ", " + originY + ", " + z);
         plugin.getDatabaseManager().savePlayerPlot(uuid, world.getName(), x, originY, z);
+        
         return loc;
     }
 
@@ -287,9 +185,8 @@ public class PlantationAreaManager {
         for (int x = x1; x <= x2; x++) {
             for (int z = z1; z <= z2; z++) {
                 world.getBlockAt(x, y - 1, z).setType(Material.GRASS_BLOCK);
-                world.getBlockAt(x, y - 2, z).setType(Material.DIRT);
-                world.getBlockAt(x, y - 3, z).setType(Material.STONE);
 
+                // Clear above ground
                 world.getBlockAt(x, y, z).setType(Material.AIR);
                 world.getBlockAt(x, y + 1, z).setType(Material.AIR);
                 world.getBlockAt(x, y + 2, z).setType(Material.AIR);
@@ -308,20 +205,44 @@ public class PlantationAreaManager {
 
         // Add gate at front center
         int gateX = x1 + plotWidth / 2;
-        world.getBlockAt(gateX, y, z1).setType(gateMaterial);
+        world.getBlockAt(gateX, y, z2).setType(gateMaterial);
 
-        // Add decorative path
-        for (int z = z1 + 1; z < z1 + 4; z++) {
-            world.getBlockAt(gateX, y - 1, z).setType(Material.DIRT_PATH);
+        // Build central path from spawn to back
+        Material pathMat = Material.matchMaterial(
+            plugin.getConfig().getString("blocks.path", "DIRT_PATH")
+        );
+        if (pathMat == null) pathMat = Material.DIRT_PATH;
+
+        for (int z = z1 + 1; z < z2; z++) {
+            world.getBlockAt(x1 + 8, y, z).setType(pathMat);
         }
 
-        // Add lanterns
-        world.getBlockAt(gateX - 1, y + 1, z1).setType(Material.LANTERN);
-        world.getBlockAt(gateX + 1, y + 1, z1).setType(Material.LANTERN);
-        world.getBlockAt(x1, y + 1, z1).setType(Material.LANTERN);
-        world.getBlockAt(x2, y + 1, z1).setType(Material.LANTERN);
-        world.getBlockAt(x1, y + 1, z2).setType(Material.LANTERN);
-        world.getBlockAt(x2, y + 1, z2).setType(Material.LANTERN);
+        // Add some decorative elements
+        world.getBlockAt(gateX - 1, y + 1, z2).setType(Material.LANTERN);
+        world.getBlockAt(gateX + 1, y + 1, z2).setType(Material.LANTERN);
+    }
+
+    public Location getOrCreateFarmAnchor(UUID owner, FarmType type, int instanceId) {
+        PlantationArea area = areas.get(owner);
+        if (area == null) {
+            Player player = Bukkit.getPlayer(owner);
+            if (player != null) {
+                area = getOrCreateArea(player);
+            } else {
+                return null;
+            }
+        }
+
+        // Get the relative position for this farm type and instance
+        List<int[]> positions = FARM_LAYOUT.get(type);
+        if (positions == null || instanceId < 1 || instanceId > positions.size()) {
+            return null;
+        }
+
+        int[] relativePos = positions.get(instanceId - 1);
+        Location anchorLoc = area.origin.clone().add(relativePos[0], 0, relativePos[1]);
+
+        return anchorLoc;
     }
 
     public boolean isLocationInPlantation(UUID owner, Location loc) {
@@ -333,7 +254,6 @@ public class PlantationAreaManager {
         PlantationArea area = areas.get(owner);
         if (area == null) return -1;
 
-        // Check all possible positions for this farm type
         List<int[]> positions = FARM_LAYOUT.get(type);
         if (positions != null) {
             for (int i = 0; i < positions.size(); i++) {
@@ -343,7 +263,7 @@ public class PlantationAreaManager {
                 if (farmLoc.getBlockX() == loc.getBlockX() &&
                     farmLoc.getBlockY() == loc.getBlockY() &&
                     farmLoc.getBlockZ() == loc.getBlockZ()) {
-                    return i + 1; // Instance IDs start at 1
+                    return i + 1;
                 }
             }
         }
@@ -356,64 +276,62 @@ public class PlantationAreaManager {
         return positions != null ? positions.size() : 0;
     }
 
-    public boolean isInstanceAvailable(UUID owner, FarmType type, int instanceId) {
-        if (instanceId < 1 || instanceId > getMaxInstances(type)) {
-            return false;
-        }
-
-        PlantationArea area = areas.get(owner);
-        if (area == null) return true;
-
-        return area.getFarmAnchor(type, instanceId) == null;
-    }
-
-    public Map<FarmType, Map<Integer, Location>> getAllFarmAnchors(UUID owner) {
-        PlantationArea area = areas.get(owner);
-        if (area == null) return new EnumMap<>(FarmType.class);
-
-        Map<FarmType, Map<Integer, Location>> result = new EnumMap<>(FarmType.class);
-        for (Map.Entry<FarmType, Map<Integer, FarmAnchor>> typeEntry : area.anchors.entrySet()) {
-            Map<Integer, Location> locations = new HashMap<>();
-            for (Map.Entry<Integer, FarmAnchor> anchorEntry : typeEntry.getValue().entrySet()) {
-                locations.put(anchorEntry.getKey(), anchorEntry.getValue().location);
-            }
-            result.put(typeEntry.getKey(), locations);
-        }
-        return result;
-    }
-
-    /** Zbuduj layout i postaw "LOCKED" dla nieodblokowanych */
+    /** Regenerate player's plantation area with proper layout */
     public void regeneratePlayerArea(Player player) {
-        World w = Bukkit.getWorld(plugin.getConfig().getString("plantation.world", "world"));
-        int baseX = plugin.getConfig().getInt("plantation.spawn.x");
-        int baseY = plugin.getConfig().getInt("plantation.spawn.y");
-        int baseZ = plugin.getConfig().getInt("plantation.spawn.z");
-
-        if (w == null) {
-            plugin.getLogger().warning("World not found for plantation.world!");
+        if (world == null) {
+            plugin.getLogger().warning("World not found for regeneration!");
             return;
         }
 
-        buildPath(w, baseX, baseY, 998, 989);
+        PlantationArea area = getOrCreateArea(player);
+        if (area == null) return;
 
-        Map<FarmType, List<Location>> anchors = computeAnchors(w, baseY);
-
+        Location origin = area.origin;
         UUID uid = player.getUniqueId();
+        
+        // Clear and rebuild the basic structure
+        buildPlotStructure(origin);
+
+        // Get player's owned farms
         List<FarmInstance> owned = plugin.getPlantationManager().getPlayerFarms(uid);
         Set<String> ownedKeys = owned.stream()
             .map(fi -> key(fi.getFarmType(), fi.getInstanceId()))
             .collect(Collectors.toSet());
 
-        for (Map.Entry<FarmType, List<Location>> e : anchors.entrySet()) {
-            FarmType type = e.getKey();
-            List<Location> list = e.getValue();
-            for (int i = 0; i < list.size(); i++) {
-                Location loc = list.get(i);
+        // Process each farm type
+        for (Map.Entry<FarmType, List<int[]>> entry : FARM_LAYOUT.entrySet()) {
+            FarmType type = entry.getKey();
+            List<int[]> positions = entry.getValue();
+            
+            for (int i = 0; i < positions.size(); i++) {
+                int[] relativePos = positions.get(i);
+                Location farmLoc = origin.clone().add(relativePos[0], 0, relativePos[1]);
                 String k = key(type, i + 1);
+                
+                // Place grass underneath
+                world.getBlockAt(farmLoc.getBlockX(), farmLoc.getBlockY() - 1, farmLoc.getBlockZ())
+                    .setType(Material.GRASS_BLOCK);
+                
                 if (ownedKeys.contains(k)) {
-                    placeFarmBlock(loc, type);
+                    // Player owns this farm - place the farm block
+                    placeFarmBlock(farmLoc, type);
+                    
+                    // Update hologram
+                    FarmInstance farm = plugin.getPlantationManager()
+                        .getFarmInstance(uid, type, i + 1);
+                    if (farm != null) {
+                        farm.setLocation(farmLoc);
+                        if (plugin.getHologramManager() != null) {
+                            plugin.getHologramManager().updateHologram(farm);
+                        }
+                    }
+                } else if (type == FarmType.BERRY_ORCHARDS || 
+                          plugin.getDatabaseManager().isFarmUnlocked(uid, type.getId())) {
+                    // Farm type unlocked but instance not created - show farm block dim
+                    placeFarmBlock(farmLoc, type);
                 } else {
-                    placeLockedSign(loc, type, i + 1);
+                    // Farm type is locked - place locked sign
+                    placeLockedSign(farmLoc, type, i + 1);
                 }
             }
         }
@@ -423,81 +341,26 @@ public class PlantationAreaManager {
         return t.getId() + "#" + id;
     }
 
-    private void buildPath(World w, int x, int y, int zFrom, int zTo) {
-        Material pathMat = Material.matchMaterial(
-            plugin.getConfig().getString("blocks.path", "DIRT_PATH")
-        );
-        if (pathMat == null) pathMat = Material.DIRT_PATH;
-
-        int dz = zFrom <= zTo ? 1 : -1;
-        for (int z = zFrom; z != zTo + dz; z += dz) {
-            Block b = w.getBlockAt(x, y, z);
-            b.setType(pathMat, false);
-        }
-    }
-
-    /** Wylicza dokładne pozycje wg Twoich koordów (Y z configu) */
-    private Map<FarmType, List<Location>> computeAnchors(World w, int y) {
-        Map<FarmType, List<Location>> map = new LinkedHashMap<>();
-
-        Function<int[], Location> L = arr -> new Location(w, arr[0], y, arr[1]);
-        BiFunction<int[], int[], List<Location>> rect6 = (a, b) -> {
-            int x1 = Math.min(a[0], b[0]), x2 = Math.max(a[0], b[0]);
-            int z1 = Math.min(a[1], b[1]), z2 = Math.max(a[1], b[1]);
-            int[] xs = new int[]{x1, x1 + 2, x1 + 4};
-            int[] zs = (z2 - z1 == 2) ? new int[]{z2, z1} : new int[]{z1, z2};
-            return Arrays.asList(
-                L.apply(new int[]{xs[0], zs[0]}),
-                L.apply(new int[]{xs[1], zs[0]}),
-                L.apply(new int[]{xs[2], zs[0]}),
-                L.apply(new int[]{xs[0], zs[1]}),
-                L.apply(new int[]{xs[1], zs[1]}),
-                L.apply(new int[]{xs[2], zs[1]})
-            );
-        };
-        BiFunction<int[], int[], List<Location>> line3 = (a, b) -> {
-            int x1 = Math.min(a[0], b[0]), x2 = Math.max(a[0], b[0]);
-            int z = a[1];
-            return Arrays.asList(
-                L.apply(new int[]{x1, z}),
-                L.apply(new int[]{x1 + 2, z}),
-                L.apply(new int[]{x2, z})
-            );
-        };
-
-        map.put(FarmType.BERRY_ORCHARDS, rect6.apply(new int[]{1010, 997}, new int[]{1014, 995}));
-        map.put(FarmType.MELON_GROVES, rect6.apply(new int[]{1002, 995}, new int[]{1006, 997}));
-        map.put(FarmType.FUNGAL_CAVERNS, rect6.apply(new int[]{1010, 993}, new int[]{1014, 991}));
-        map.put(FarmType.PUMPKIN_PATCHES, rect6.apply(new int[]{1002, 991}, new int[]{1006, 993}));
-        map.put(FarmType.MYSTIC_GARDENS, line3.apply(new int[]{1010, 989}, new int[]{1014, 989}));
-        map.put(FarmType.ANCIENT_MANGROVES, line3.apply(new int[]{1002, 989}, new int[]{1006, 989}));
-        map.put(FarmType.DESERT_SANCTUARIES, Arrays.asList(L.apply(new int[]{1008, 987})));
-
-        return map;
-    }
-
     public void placeFarmBlock(Location loc, FarmType type) {
-        Material ground = Material.matchMaterial(plugin.getConfig().getString("blocks.ground", "GRASS_BLOCK"));
-        if (ground == null) ground = Material.GRASS_BLOCK;
-        loc.getBlock().getWorld().getBlockAt(loc.getBlockX(), loc.getBlockY() - 1, loc.getBlockZ()).setType(ground, false);
-
-        loc.getBlock().setType(type.getBlockType(), false);
+        Block farmBlock = world.getBlockAt(loc);
+        farmBlock.setType(type.getBlockType(), false);
     }
 
     private void placeLockedSign(Location loc, FarmType type, int instanceId) {
-        loc.getBlock().setType(Material.AIR, false);
-        loc.getWorld().getBlockAt(loc.getBlockX(), loc.getBlockY() - 1, loc.getBlockZ()).setType(Material.GRASS_BLOCK, false);
-
-        loc.getBlock().setType(Material.OAK_SIGN, false);
-        BlockState state = loc.getBlock().getState();
+        Block block = world.getBlockAt(loc);
+        block.setType(Material.OAK_SIGN, false);
+        
+        BlockState state = block.getState();
         if (state instanceof Sign sign) {
             sign.setLine(0, ChatColor.RED + "LOCKED");
             sign.setLine(1, ChatColor.YELLOW + type.getDisplayName());
-            sign.setLine(2, ChatColor.GRAY + "Prawy klik aby");
-            sign.setLine(3, ChatColor.GRAY + "odblokować");
+            sign.setLine(2, ChatColor.GRAY + "Right-click to");
+            sign.setLine(3, ChatColor.GRAY + "unlock");
+            
             sign.getPersistentDataContainer().set(PDC_LOCKED, PersistentDataType.INTEGER, 1);
             sign.getPersistentDataContainer().set(PDC_FARM_TYPE, PersistentDataType.STRING, type.getId());
             sign.getPersistentDataContainer().set(PDC_INSTANCE_ID, PersistentDataType.INTEGER, instanceId);
+            
             sign.update(true, false);
         }
     }
@@ -505,15 +368,12 @@ public class PlantationAreaManager {
     public static class PlantationArea {
         private final UUID owner;
         private final Location origin;
-        private final Map<FarmType, Map<Integer, FarmAnchor>> anchors;
         private final int width;
         private final int depth;
 
-        PlantationArea(UUID owner, Location origin, Map<FarmType, Map<Integer, FarmAnchor>> anchors,
-                      int width, int depth) {
+        PlantationArea(UUID owner, Location origin, int width, int depth) {
             this.owner = owner;
             this.origin = origin;
-            this.anchors = anchors != null ? anchors : new EnumMap<>(FarmType.class);
             this.width = width;
             this.depth = depth;
         }
@@ -523,7 +383,8 @@ public class PlantationAreaManager {
         }
 
         public Location getSpawnPoint() {
-            return origin.clone().add(width / 2.0, 1, 2);
+            // Spawn point is at the center-back of the plot
+            return origin.clone().add(8, 1, depth - 1);
         }
 
         boolean contains(Location loc) {
@@ -536,15 +397,6 @@ public class PlantationAreaManager {
             int z1 = origin.getBlockZ();
 
             return x >= x1 && x < x1 + width && z >= z1 && z < z1 + depth;
-        }
-
-        FarmAnchor getFarmAnchor(FarmType type, int instanceId) {
-            Map<Integer, FarmAnchor> typeAnchors = anchors.get(type);
-            return typeAnchors != null ? typeAnchors.get(instanceId) : null;
-        }
-
-        void addFarmAnchor(FarmType type, int instanceId, FarmAnchor anchor) {
-            anchors.computeIfAbsent(type, k -> new HashMap<>()).put(instanceId, anchor);
         }
 
         public UUID getOwner() {
@@ -568,4 +420,3 @@ public class PlantationAreaManager {
         }
     }
 }
-

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
@@ -578,6 +578,8 @@ public class PlantationManager {
     public long getHarvestIntervalMillis(FarmInstance farm) {
         if (plugin.getConfig().getBoolean("test_mode.enabled", false)) {
             int mins = plugin.getConfig().getInt("test_mode.growth_minutes", 1);
+            plugin.getLogger().info("TEST MODE: Farm " + farm.getFarmType().getId() +
+                                   " will grow in " + mins + " minute(s)");
             return TimeUnit.MINUTES.toMillis(mins);
         }
         return TimeUnit.SECONDS.toMillis(farm.getFarmType().getHarvestSeconds());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,12 +30,11 @@ plantations:
       x: 1000
       y: 100
       z: 1000
-    plot:
-      width: 17
-      height: 15
-      depth: 16
-      fence_material: OAK_FENCE
-      gate_material: OAK_FENCE_GATE
+      plot:
+        width: 17
+        depth: 15
+        fence_material: OAK_FENCE
+        gate_material: OAK_FENCE_GATE
     spacing: 20
     grid:
       rows: 10
@@ -99,7 +98,7 @@ plantation:
     y: 64
     z: 998
   holograms:
-    y_offset: -0.6
+    y_offset: 2.0
   rebuild_on_join: true
 
 # --- TRYB TESTOWY ---
@@ -107,7 +106,7 @@ test_mode:
   enabled: true
   growth_minutes: 1
 
-# (opcjonalnie) materiały pod uprawy/ścieżki
+# (optional) materials for crops/paths
 blocks:
   path: DIRT_PATH
   ground: GRASS_BLOCK


### PR DESCRIPTION
## Summary
- Translate remaining player-facing messages to English
- Warn when test mode is enabled and log farm growth overrides
- Set default hologram height offset to 2.0 via config
- Refactor plantation grid layout to prevent overlapping farm plots
- Clean up plot dimensions in config

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68add87a54f0832aa203f329e8dc2522