### PR TITLE
Handle missing plantation plot configuration

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -98,20 +98,36 @@ public class PlantationAreaManager {
         this.PDC_INSTANCE_ID = new NamespacedKey(plugin, "instance_id");
 
         ConfigurationSection base = plugin.getConfig().getConfigurationSection("plantations.base");
+        if (base == null) {
+            throw new IllegalStateException("Missing 'plantations.base' section in config");
+        }
+
         this.world = Bukkit.getWorld(plugin.getConfig().getString("plantations.world", "world"));
 
         ConfigurationSection originSec = base.getConfigurationSection("origin");
+        if (originSec == null) {
+            throw new IllegalStateException("Missing 'plantations.base.origin' section in config");
+        }
         this.originX = originSec.getInt("x");
         this.originY = originSec.getInt("y");
         this.originZ = originSec.getInt("z");
 
         ConfigurationSection plotSec = base.getConfigurationSection("plot");
-        this.fenceMaterial = Material.valueOf(plotSec.getString("fence_material", "OAK_FENCE"));
-        this.gateMaterial = Material.valueOf(plotSec.getString("gate_material", "OAK_FENCE_GATE"));
+        if (plotSec == null) {
+            plugin.getLogger().warning("Missing 'plantations.base.plot' section in config; using default fence and gate materials.");
+            this.fenceMaterial = Material.OAK_FENCE;
+            this.gateMaterial = Material.OAK_FENCE_GATE;
+        } else {
+            this.fenceMaterial = Material.valueOf(plotSec.getString("fence_material", "OAK_FENCE"));
+            this.gateMaterial = Material.valueOf(plotSec.getString("gate_material", "OAK_FENCE_GATE"));
+        }
 
         this.spacing = base.getInt("spacing");
 
         ConfigurationSection gridSec = base.getConfigurationSection("grid");
+        if (gridSec == null) {
+            throw new IllegalStateException("Missing 'plantations.base.grid' section in config");
+        }
         this.gridRows = gridSec.getInt("rows");
         this.gridCols = gridSec.getInt("cols");
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,11 +30,11 @@ plantations:
       x: 1000
       y: 100
       z: 1000
-      plot:
-        width: 17
-        depth: 15
-        fence_material: OAK_FENCE
-        gate_material: OAK_FENCE_GATE
+    plot:
+      width: 17
+      depth: 15
+      fence_material: OAK_FENCE
+      gate_material: OAK_FENCE_GATE
     spacing: 20
     grid:
       rows: 10


### PR DESCRIPTION
## Summary
- validate required plantation configuration sections and default missing plot materials
- fix default config.yml layout to correctly place plot settings

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68addf370284832aae12a9e2f8a1c422