### PR TITLE
Fix async growth and quick sell interactions

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/fruits/FruitType.java
+++ b/src/main/java/org/maks/farmingPlugin/fruits/FruitType.java
@@ -90,8 +90,6 @@ public enum FruitType {
             loreList.add("");
             loreList.add(ChatColor.YELLOW + "⚡ Quick Sell Value:");
             loreList.add(ChatColor.GOLD + "$" + String.format("%,d", sellPrice) + " each");
-            loreList.add("");
-            loreList.add(ChatColor.DARK_GRAY + "Right-click to eat!");
 
             meta.setLore(loreList);
 


### PR DESCRIPTION
## Summary
- run offline growth checks on the main thread and save player data asynchronously
- ensure `processFarmHarvest` only runs on the main thread and save data after harvest
- allow placing fruit items in Quick Sell GUI and remove "Right-click to eat" lore from fruits

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade611a674832ab36a212cd2d078b2