### PR TITLE
Fix adventure mode interaction and material parsing

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/farms/FarmInstance.java
+++ b/src/main/java/org/maks/farmingPlugin/farms/FarmInstance.java
@@ -299,7 +299,7 @@ public class FarmInstance {
                 materials.put(MaterialType.MUSHROOM_SPORES, 8 * nextLevel);
             }
             case "quality" -> {
-                materials.put(MaterialType.HERBAL_EXTRACT, 10 * nextLevel);
+                materials.put(MaterialType.HERB_EXTRACT, 10 * nextLevel);
                 materials.put(MaterialType.BEESWAX_CHUNK, 5 * nextLevel);
                 if (nextLevel > 3) {
                     materials.put(MaterialType.DRUIDIC_ESSENCE, 3 * (nextLevel - 3));

--- a/src/main/java/org/maks/farmingPlugin/listeners/PlantationListeners.java
+++ b/src/main/java/org/maks/farmingPlugin/listeners/PlantationListeners.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
@@ -20,6 +21,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
@@ -92,11 +94,17 @@ public class PlantationListeners implements Listener {
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
-        
+
         Player player = event.getPlayer();
         Block block = event.getClickedBlock();
-        
+
         if (block == null) return;
+
+        // Allow Adventure mode players to interact with farm blocks
+        if (player.getGameMode() == GameMode.ADVENTURE) {
+            event.setUseInteractedBlock(Event.Result.ALLOW);
+            event.setUseItemInHand(Event.Result.DENY);
+        }
         
         // Check for cooldown
         if (isOnCooldown(player)) {

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationAreaManager.java
@@ -37,7 +37,7 @@ public class PlantationAreaManager {
     private final int plotDepth = 15;
     private final int spacing;
     private final int gridRows, gridCols;
-    private final Material fenceMaterial, gateMaterial;
+    private final Material fenceMaterial;
 
     private NamespacedKey PDC_LOCKED;
     private NamespacedKey PDC_FARM_TYPE;
@@ -114,12 +114,10 @@ public class PlantationAreaManager {
 
         ConfigurationSection plotSec = base.getConfigurationSection("plot");
         if (plotSec == null) {
-            plugin.getLogger().warning("Missing 'plantations.base.plot' section in config; using default fence and gate materials.");
+            plugin.getLogger().warning("Missing 'plantations.base.plot' section in config; using default fence material.");
             this.fenceMaterial = Material.OAK_FENCE;
-            this.gateMaterial = Material.OAK_FENCE_GATE;
         } else {
             this.fenceMaterial = Material.valueOf(plotSec.getString("fence_material", "OAK_FENCE"));
-            this.gateMaterial = Material.valueOf(plotSec.getString("gate_material", "OAK_FENCE_GATE"));
         }
 
         this.spacing = base.getInt("spacing");
@@ -208,34 +206,30 @@ public class PlantationAreaManager {
                 world.getBlockAt(x, y, z).setType(Material.AIR);
                 world.getBlockAt(x, y + 1, z).setType(Material.AIR);
                 world.getBlockAt(x, y + 2, z).setType(Material.AIR);
+                world.getBlockAt(x, y + 3, z).setType(Material.AIR);
+                world.getBlockAt(x, y + 4, z).setType(Material.AIR);
             }
         }
 
-        // Build fence perimeter with barrier above to keep drops contained
+        // Build fence perimeter with high barriers to contain players and drops
         for (int x = x1; x <= x2; x++) {
             world.getBlockAt(x, y, z1).setType(fenceMaterial);
-            world.getBlockAt(x, barrierY, z1).setType(Material.BARRIER);
-
             world.getBlockAt(x, y, z2).setType(fenceMaterial);
-            if (x != gateX && x != gateX - 1 && x != gateX + 1) {
-                world.getBlockAt(x, barrierY, z2).setType(Material.BARRIER);
+
+            for (int by = barrierY; by < barrierY + 4; by++) {
+                world.getBlockAt(x, by, z1).setType(Material.BARRIER);
+                world.getBlockAt(x, by, z2).setType(Material.BARRIER);
             }
         }
         for (int z = z1 + 1; z < z2; z++) {
             world.getBlockAt(x1, y, z).setType(fenceMaterial);
-            world.getBlockAt(x1, barrierY, z).setType(Material.BARRIER);
-
             world.getBlockAt(x2, y, z).setType(fenceMaterial);
-            world.getBlockAt(x2, barrierY, z).setType(Material.BARRIER);
+
+            for (int by = barrierY; by < barrierY + 4; by++) {
+                world.getBlockAt(x1, by, z).setType(Material.BARRIER);
+                world.getBlockAt(x2, by, z).setType(Material.BARRIER);
+            }
         }
-
-        // Add barriers above gate and lantern spots
-        world.getBlockAt(gateX, barrierY + 1, z2).setType(Material.BARRIER);
-        world.getBlockAt(gateX - 1, barrierY + 1, z2).setType(Material.BARRIER);
-        world.getBlockAt(gateX + 1, barrierY + 1, z2).setType(Material.BARRIER);
-
-        // Add gate at front center
-        world.getBlockAt(gateX, y, z2).setType(gateMaterial);
 
         // Build central path from spawn to back
         Material pathMat = Material.matchMaterial(

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
@@ -57,7 +57,7 @@ public class PlantationManager {
         farmDrops.put(FarmType.BERRY_ORCHARDS, Arrays.asList(
             new MaterialDrop(MaterialType.PLANT_FIBER, 1, 15.0),
             new MaterialDrop(MaterialType.PLANT_FIBER, 2, 5.0),
-            new MaterialDrop(MaterialType.HERBAL_EXTRACT, 1, 3.0)
+            new MaterialDrop(MaterialType.HERB_EXTRACT, 1, 3.0)
         ));
 
         farmDrops.put(FarmType.MELON_GROVES, Arrays.asList(
@@ -83,9 +83,9 @@ public class PlantationManager {
         ));
 
         farmDrops.put(FarmType.MYSTIC_GARDENS, Arrays.asList(
-            new MaterialDrop(MaterialType.HERBAL_EXTRACT, 1, 8.0),
-            new MaterialDrop(MaterialType.HERBAL_EXTRACT, 2, 5.0),
-            new MaterialDrop(MaterialType.HERBAL_EXTRACT, 3, 2.0),
+            new MaterialDrop(MaterialType.HERB_EXTRACT, 1, 8.0),
+            new MaterialDrop(MaterialType.HERB_EXTRACT, 2, 5.0),
+            new MaterialDrop(MaterialType.HERB_EXTRACT, 3, 2.0),
             new MaterialDrop(MaterialType.BEESWAX_CHUNK, 1, 6.0),
             new MaterialDrop(MaterialType.BEESWAX_CHUNK, 2, 3.0)
         ));
@@ -110,7 +110,7 @@ public class PlantationManager {
         // Load unlock requirements (unchanged)
         Map<MaterialType, Integer> melonReq = new HashMap<>();
         melonReq.put(MaterialType.PLANT_FIBER, 50);
-        melonReq.put(MaterialType.HERBAL_EXTRACT, 10);
+        melonReq.put(MaterialType.HERB_EXTRACT, 10);
         unlockRequirements.put(FarmType.MELON_GROVES, melonReq);
 
         Map<MaterialType, Integer> fungalReq = new HashMap<>();
@@ -130,7 +130,7 @@ public class PlantationManager {
         unlockRequirements.put(FarmType.MYSTIC_GARDENS, mysticReq);
 
         Map<MaterialType, Integer> mangroveReq = new HashMap<>();
-        mangroveReq.put(MaterialType.HERBAL_EXTRACT, 25);
+        mangroveReq.put(MaterialType.HERB_EXTRACT, 25);
         mangroveReq.put(MaterialType.BEESWAX_CHUNK, 15);
         mangroveReq.put(MaterialType.COMPOST_DUST, 10);
         unlockRequirements.put(FarmType.ANCIENT_MANGROVES, mangroveReq);
@@ -138,7 +138,7 @@ public class PlantationManager {
         Map<MaterialType, Integer> desertReq = new HashMap<>();
         desertReq.put(MaterialType.DRUIDIC_ESSENCE, 10);
         desertReq.put(MaterialType.BEESWAX_CHUNK, 15);
-        desertReq.put(MaterialType.HERBAL_EXTRACT, 8);
+        desertReq.put(MaterialType.HERB_EXTRACT, 8);
         unlockRequirements.put(FarmType.DESERT_SANCTUARIES, desertReq);
     }
 

--- a/src/main/java/org/maks/farmingPlugin/materials/MaterialManager.java
+++ b/src/main/java/org/maks/farmingPlugin/materials/MaterialManager.java
@@ -11,6 +11,7 @@ import org.maks.farmingPlugin.FarmingPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 
 public class MaterialManager {
     private final FarmingPlugin plugin;
@@ -73,7 +74,7 @@ public class MaterialManager {
         if (materialId != null && materialId.startsWith("farmer_")) {
             String[] parts = materialId.substring(7).split("_");
             if (parts.length >= 2) {
-                String typeId = parts[0] + "_" + parts[1];
+                String typeId = String.join("_", Arrays.copyOf(parts, parts.length - 1));
                 return MaterialType.fromId(typeId);
             }
         }

--- a/src/main/java/org/maks/farmingPlugin/materials/MaterialType.java
+++ b/src/main/java/org/maks/farmingPlugin/materials/MaterialType.java
@@ -7,7 +7,7 @@ public enum MaterialType {
     SEED_POUCH("seed_pouch", "Seed Pouch", Material.WHEAT_SEEDS, MaterialRarity.BASIC),
     COMPOST_DUST("compost_dust", "Compost Dust", Material.BONE_MEAL, MaterialRarity.BASIC),
     
-    HERBAL_EXTRACT("herbal_extract", "Herbal Extract", Material.SPIDER_EYE, MaterialRarity.RARE),
+    HERB_EXTRACT("herb_extract", "Herbal Extract", Material.SPIDER_EYE, MaterialRarity.RARE),
     MUSHROOM_SPORES("mushroom_spores", "Mushroom Spores", Material.BROWN_MUSHROOM, MaterialRarity.RARE),
     BEESWAX_CHUNK("beeswax_chunk", "Beeswax Chunk", Material.BOOK, MaterialRarity.RARE),
     

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,7 +34,6 @@ plantations:
       width: 17
       depth: 15
       fence_material: OAK_FENCE
-      gate_material: OAK_FENCE_GATE
     spacing: 20
     grid:
       rows: 10


### PR DESCRIPTION
## Summary
- Allow adventure-mode players to interact with farm blocks
- Improve material ID parsing to avoid unknown crafting materials
- Replace front gate with fenced perimeter and taller barriers
- Rename herbal extract ID to match defined crafting materials

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adee54dfb4832aa3f70293c1836640