### PR TITLE
Force hologram refresh after harvest

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/gui/PlantationGUI.java
+++ b/src/main/java/org/maks/farmingPlugin/gui/PlantationGUI.java
@@ -324,7 +324,7 @@ public class PlantationGUI implements InventoryHolder {
         
         // Update hologram when GUI is refreshed (storage might have changed)
         if (plugin.getHologramManager() != null) {
-            plugin.getHologramManager().updateHologram(farmInstance);
+            plugin.getHologramManager().updateHologram(farmInstance, true);
         }
     }
 

--- a/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/HologramManager.java
@@ -43,19 +43,27 @@ public class HologramManager {
      * Create or update hologram for a farm instance
      */
     public void updateHologram(FarmInstance farm) {
+        updateHologram(farm, false);
+    }
+
+    /**
+     * Create or update hologram for a farm instance
+     * @param force If true, bypasses the update cooldown
+     */
+    public void updateHologram(FarmInstance farm, boolean force) {
         if (!enabled || farm.getLocation() == null) return;
-        
+
         String hologramKey = getHologramKey(farm);
-        
+
         // Check update cooldown to prevent flickering
         Long lastUpdate = lastUpdateTimes.get(hologramKey);
-        if (lastUpdate != null && System.currentTimeMillis() - lastUpdate < UPDATE_COOLDOWN) {
+        if (!force && lastUpdate != null && System.currentTimeMillis() - lastUpdate < UPDATE_COOLDOWN) {
             return; // Skip update if too soon
         }
-        
+
         // Remove old hologram if exists
         removeHologram(hologramKey);
-        
+
         // Create new hologram lines
         List<String> lines = generateHologramLines(farm);
         Location baseLocation = holoLoc(farm.getLocation());

--- a/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PlantationManager.java
@@ -395,7 +395,8 @@ public class PlantationManager {
         checkLevelUp(farm);
 
         if (plugin.getHologramManager() != null) {
-            plugin.getHologramManager().updateHologram(farm);
+            // Force update to ensure hologram reflects new state immediately after harvest
+            plugin.getHologramManager().updateHologram(farm, true);
         }
 
         player.playSound(dropLoc, Sound.ITEM_BUNDLE_DROP_CONTENTS, 1.0f, 1.0f);


### PR DESCRIPTION
## Summary
- allow forcing hologram updates to bypass cooldown
- refresh farm holograms immediately after harvesting or GUI refresh

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aecde774d0832a9dcaa94781085c2a