### PR TITLE
Fix item identification and pouch integration

### DIFF
--- a/src/main/java/org/maks/farmingPlugin/managers/PouchIntegrationManager.java
+++ b/src/main/java/org/maks/farmingPlugin/managers/PouchIntegrationManager.java
@@ -1,165 +1,345 @@
 package org.maks.farmingPlugin.managers;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.maks.farmingPlugin.FarmingPlugin;
 import org.maks.farmingPlugin.materials.MaterialType;
-import com.maks.ingredientpouchplugin.IngredientPouchPlugin;
-import com.maks.ingredientpouchplugin.api.PouchAPI;
 
+import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Level;
 
 /**
- * Handles integration with IngredientPouchPlugin to check and consume materials from pouches
+ * Handles integration with the external IngredientPouch plugin. The manager
+ * can query and modify pouch contents as well as coordinate consuming
+ * materials for upgrades across a player's inventory and pouch.
  */
 public class PouchIntegrationManager {
-    
     private final FarmingPlugin plugin;
-    private IngredientPouchPlugin pouchPlugin;
-    private PouchAPI pouchAPI;
-    private boolean enabled;
-    
+    private Object pouchAPI;
+    private Method getItemQuantityMethod;
+    private Method updateItemQuantityMethod;
+    private boolean enabled = false;
+
     public PouchIntegrationManager(FarmingPlugin plugin) {
         this.plugin = plugin;
-        this.enabled = false;
-        
-        // Try to hook into IngredientPouchPlugin
-        Plugin pouchPluginInstance = Bukkit.getPluginManager().getPlugin("IngredientPouchPlugin");
-        if (pouchPluginInstance instanceof IngredientPouchPlugin) {
-            this.pouchPlugin = (IngredientPouchPlugin) pouchPluginInstance;
-            this.pouchAPI = pouchPlugin.getAPI();
-            this.enabled = true;
-            plugin.getLogger().info("Successfully hooked into IngredientPouchPlugin!");
-        } else {
-            plugin.getLogger().info("IngredientPouchPlugin not found, pouch integration disabled.");
+        initialize();
+    }
+
+    /**
+     * Try to hook into IngredientPouchAPI if the plugin is present.
+     */
+    private void initialize() {
+        try {
+            Plugin pouchPlugin = plugin.getServer().getPluginManager().getPlugin("IngredientPouchPlugin");
+            if (pouchPlugin != null) {
+                Method getAPIMethod = pouchPlugin.getClass().getMethod("getAPI");
+                Object apiInstance = getAPIMethod.invoke(pouchPlugin);
+                if (apiInstance != null) {
+                    pouchAPI = apiInstance;
+                    Class<?> apiClass = apiInstance.getClass();
+                    getItemQuantityMethod = apiClass.getMethod("getItemQuantity", String.class, String.class);
+                    updateItemQuantityMethod = apiClass.getMethod("updateItemQuantity", String.class, String.class, int.class);
+                    enabled = true;
+                    plugin.getLogger().info("✓ Successfully hooked into IngredientPouchPlugin!");
+                } else {
+                    plugin.getLogger().warning("IngredientPouchPlugin found but API is not available!");
+                }
+            } else {
+                plugin.getLogger().info("IngredientPouchPlugin not found - pouch integration disabled");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to initialize IngredientPouch integration", e);
+            enabled = false;
         }
     }
-    
-    /**
-     * Check if pouch integration is available
-     */
+
     public boolean isEnabled() {
         return enabled;
     }
-    
+
     /**
-     * Get the pouch item key for a farming material
-     * Maps farming plugin materials to pouch plugin item IDs
+     * Build the pouch item key for a given material type and tier.
+     * Format: farmer_[material_id]_[tier_roman]
      */
-    private String getPouchItemKey(String materialId, int tier) {
-        // Map farming materials to pouch item IDs
-        // This might need adjustment based on actual pouch items
-        return switch (materialId) {
-            case "plant_fiber" -> "plant_fiber";  // Direct mapping
-            case "seed_pouch" -> "seed_pouch";    // Direct mapping  
-            case "compost_dust" -> "compost_dust"; // Direct mapping
-            case "herb_extract" -> "herb_extract"; // Direct mapping
-            case "mushroom_spores" -> "mushroom_spores"; // Direct mapping
-            case "beeswax_chunk" -> "beeswax_chunk"; // Direct mapping
-            case "druidic_essence" -> "druidic_essence"; // Direct mapping
-            case "golden_truffle" -> "golden_truffle"; // Direct mapping
-            case "ancient_grain" -> "ancient_grain"; // Direct mapping
-            default -> materialId; // Fallback to original ID
+    private String getPouchItemKey(MaterialType materialType, int tier) {
+        String tierRoman = switch (tier) {
+            case 1 -> "I";
+            case 2 -> "II";
+            case 3 -> "III";
+            default -> "I";
         };
+
+        return "farmer_" + materialType.getId() + "_" + tierRoman;
     }
 
     /**
-     * Check if player has enough of a material in their pouch
+     * Check if player has specific amount of material in their pouch.
      */
-    public boolean hasIngredientInPouch(UUID playerUuid, String materialId, int tier, int amount) {
-        if (!enabled) return false;
-        
+    public boolean hasIngredientInPouch(UUID playerUuid, MaterialType materialType, int tier, int amount) {
+        if (!enabled || pouchAPI == null) {
+            return false;
+        }
+
         try {
-            String ingredientKey = getPouchItemKey(materialId, tier);
-            int available = pouchAPI.getItemQuantity(playerUuid.toString(), ingredientKey);
-            return available >= amount;
+            String itemKey = getPouchItemKey(materialType, tier);
+            Object result = getItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey);
+            int currentAmount = result instanceof Integer ? (Integer) result : 0;
+
+            plugin.debug("Checking pouch for " + itemKey + ": has " + currentAmount + ", needs " + amount);
+
+            return currentAmount >= amount;
         } catch (Exception e) {
-            plugin.getLogger().warning("Error checking pouch ingredient: " + e.getMessage());
+            plugin.getLogger().warning("Error checking pouch ingredient for " + playerUuid + ": " + e.getMessage());
             return false;
         }
     }
-    
+
     /**
-     * Remove materials from player's pouch
+     * Add materials to player's pouch.
      */
-    public boolean removeIngredientFromPouch(UUID playerUuid, String materialId, int tier, int amount) {
-        if (!enabled) return false;
-        
+    public boolean addIngredientToPouch(UUID playerUuid, MaterialType materialType, int tier, int amount) {
+        if (!enabled || pouchAPI == null) {
+            return false;
+        }
+
         try {
-            String ingredientKey = getPouchItemKey(materialId, tier);
-            return pouchAPI.updateItemQuantity(playerUuid.toString(), ingredientKey, -amount);
+            String itemKey = getPouchItemKey(materialType, tier);
+            Object result = updateItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey, amount);
+            boolean success = result instanceof Boolean && (Boolean) result;
+
+            if (success) {
+                plugin.debug("Added " + amount + "x " + itemKey + " to " + playerUuid + "'s pouch");
+            } else {
+                plugin.debug("Failed to add " + itemKey + " to pouch (may be full or item not registered)");
+            }
+
+            return success;
         } catch (Exception e) {
-            plugin.getLogger().warning("Error removing pouch ingredient: " + e.getMessage());
+            plugin.getLogger().warning("Error adding to pouch for " + playerUuid + ": " + e.getMessage());
             return false;
         }
     }
-    
+
+    /**
+     * Remove materials from player's pouch.
+     */
+    public boolean removeIngredientFromPouch(UUID playerUuid, MaterialType materialType, int tier, int amount) {
+        if (!enabled || pouchAPI == null) {
+            return false;
+        }
+
+        try {
+            String itemKey = getPouchItemKey(materialType, tier);
+
+            // Check current amount first
+            Object current = getItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey);
+            int currentAmount = current instanceof Integer ? (Integer) current : 0;
+            if (currentAmount < amount) {
+                plugin.debug("Not enough " + itemKey + " in pouch: has " + currentAmount + ", needs " + amount);
+                return false;
+            }
+
+            Object result = updateItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey, -amount);
+            boolean success = result instanceof Boolean && (Boolean) result;
+
+            if (success) {
+                plugin.debug("Removed " + amount + "x " + itemKey + " from " + playerUuid + "'s pouch");
+            }
+
+            return success;
+        } catch (Exception e) {
+            plugin.getLogger().warning("Error removing from pouch for " + playerUuid + ": " + e.getMessage());
+            return false;
+        }
+    }
+
     /**
      * Check if player has enough materials for upgrade (checks both inventory and pouch)
+     * @return true if player has all required materials
      */
-    public boolean hasUpgradeMaterials(Player player, java.util.Map<MaterialType, Integer> materials) {
+    public boolean hasUpgradeMaterials(Player player, Map<MaterialType, Integer> materials) {
         UUID playerUuid = player.getUniqueId();
-        
-        for (java.util.Map.Entry<MaterialType, Integer> entry : materials.entrySet()) {
+
+        for (Map.Entry<MaterialType, Integer> entry : materials.entrySet()) {
             MaterialType materialType = entry.getKey();
             int required = entry.getValue();
-            
-            // Check inventory first
-            int inInventory = plugin.getDatabaseManager()
-                .getPlayerMaterialAmount(playerUuid, materialType.getId(), 1);
-            
-            if (inInventory >= required) {
-                continue; // Has enough in inventory
+            int totalFound = 0;
+
+            // Count materials in inventory
+            totalFound += plugin.getMaterialManager().countMaterialInInventory(player, materialType, 1);
+
+            // Also check tier 2 and 3 if needed
+            if (totalFound < required) {
+                totalFound += plugin.getMaterialManager().countMaterialInInventory(player, materialType, 2);
             }
-            
-            // Check pouch for remaining amount needed
-            int needed = required - inInventory;
-            if (!hasIngredientInPouch(playerUuid, materialType.getId(), 1, needed)) {
-                return false; // Not enough in total
+            if (totalFound < required) {
+                totalFound += plugin.getMaterialManager().countMaterialInInventory(player, materialType, 3);
+            }
+
+            plugin.debug("Found " + totalFound + " " + materialType.getId() + " in inventory, need " + required);
+
+            // If not enough in inventory, check pouch
+            if (totalFound < required && enabled) {
+                int needed = required - totalFound;
+
+                // Check all tiers in pouch
+                for (int tier = 1; tier <= 3; tier++) {
+                    if (hasIngredientInPouch(playerUuid, materialType, tier, needed)) {
+                        totalFound += needed;
+                        break;
+                    }
+
+                    // Check partial amount
+                    try {
+                        String itemKey = getPouchItemKey(materialType, tier);
+                        Object current = getItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey);
+                        int pouchAmount = current instanceof Integer ? (Integer) current : 0;
+                        if (pouchAmount > 0) {
+                            totalFound += Math.min(pouchAmount, needed);
+                            needed -= Math.min(pouchAmount, needed);
+                            if (needed <= 0) break;
+                        }
+                    } catch (Exception e) {
+                        plugin.getLogger().warning("Error checking pouch ingredient for " + playerUuid + ": " + e.getMessage());
+                    }
+                }
+            }
+
+            if (totalFound < required) {
+                plugin.debug("Not enough " + materialType.getId() + ": has " + totalFound + ", needs " + required);
+                return false;
             }
         }
-        
+
         return true;
     }
-    
+
     /**
      * Consume materials for upgrade from both inventory and pouch
+     * @return true if materials were successfully consumed
      */
-    public boolean consumeUpgradeMaterials(Player player, java.util.Map<MaterialType, Integer> materials) {
+    public boolean consumeUpgradeMaterials(Player player, Map<MaterialType, Integer> materials) {
         UUID playerUuid = player.getUniqueId();
-        
-        // First pass: verify we have everything needed
+
+        // First verify we have everything
         if (!hasUpgradeMaterials(player, materials)) {
             return false;
         }
-        
-        // Second pass: consume materials
-        for (java.util.Map.Entry<MaterialType, Integer> entry : materials.entrySet()) {
+
+        // Consume materials
+        for (Map.Entry<MaterialType, Integer> entry : materials.entrySet()) {
             MaterialType materialType = entry.getKey();
             int required = entry.getValue();
-            
-            // Try to consume from inventory first
-            int inInventory = plugin.getDatabaseManager()
-                .getPlayerMaterialAmount(playerUuid, materialType.getId(), 1);
-            
-            if (inInventory > 0) {
-                int toRemoveFromInventory = Math.min(inInventory, required);
-                plugin.getDatabaseManager().updatePlayerMaterial(
-                    playerUuid, materialType.getId(), 1, -toRemoveFromInventory);
-                required -= toRemoveFromInventory;
-            }
-            
-            // Consume remaining from pouch if needed
-            if (required > 0) {
-                if (!removeIngredientFromPouch(playerUuid, materialType.getId(), 1, required)) {
-                    plugin.getLogger().warning("Failed to remove " + required + " " + 
-                        materialType.getId() + " from pouch for " + player.getName());
-                    return false;
+
+            // Try to consume from inventory first (prefer lower tiers)
+            for (int tier = 1; tier <= 3 && required > 0; tier++) {
+                int removed = plugin.getMaterialManager().removeMaterialFromInventory(
+                        player, materialType, tier, required);
+                required -= removed;
+
+                if (removed > 0) {
+                    plugin.debug("Removed " + removed + "x " + materialType.getId() + " tier " + tier + " from inventory");
                 }
             }
+
+            // Consume remaining from pouch if needed
+            if (required > 0 && enabled) {
+                for (int tier = 1; tier <= 3 && required > 0; tier++) {
+                    try {
+                        String itemKey = getPouchItemKey(materialType, tier);
+                        Object current = getItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey);
+                        int pouchAmount = current instanceof Integer ? (Integer) current : 0;
+
+                        if (pouchAmount > 0) {
+                            int toRemove = Math.min(pouchAmount, required);
+                            if (removeIngredientFromPouch(playerUuid, materialType, tier, toRemove)) {
+                                required -= toRemove;
+                                plugin.debug("Removed " + toRemove + "x " + materialType.getId() + " tier " + tier + " from pouch");
+                            }
+                        }
+                    } catch (Exception e) {
+                        plugin.getLogger().warning("Error removing from pouch for " + playerUuid + ": " + e.getMessage());
+                    }
+                }
+            }
+
+            if (required > 0) {
+                plugin.getLogger().warning("Failed to consume all required " + materialType.getId() + " for " + player.getName());
+                return false;
+            }
         }
-        
+
         return true;
     }
+
+    /**
+     * Transfer items from inventory to pouch
+     */
+    public boolean transferToPouch(Player player, MaterialType materialType, int tier, int amount) {
+        if (!enabled) {
+            player.sendMessage("§cIngredientPouch plugin is not available!");
+            return false;
+        }
+
+        UUID playerUuid = player.getUniqueId();
+
+        // Check if player has the items in inventory
+        int inventoryAmount = plugin.getMaterialManager().countMaterialInInventory(player, materialType, tier);
+        if (inventoryAmount < amount) {
+            player.sendMessage("§cYou don't have enough items to transfer!");
+            return false;
+        }
+
+        // Remove from inventory
+        int removed = plugin.getMaterialManager().removeMaterialFromInventory(player, materialType, tier, amount);
+        if (removed != amount) {
+            player.sendMessage("§cFailed to remove items from inventory!");
+            return false;
+        }
+
+        // Add to pouch
+        if (addIngredientToPouch(playerUuid, materialType, tier, removed)) {
+            player.sendMessage("§aTransferred " + removed + "x " + materialType.getDisplayName() + " Tier " + tier + " to pouch!");
+            return true;
+        } else {
+            // Failed to add to pouch, give items back
+            plugin.getMaterialManager().givePlayerMaterial(player, materialType, tier, removed);
+            player.sendMessage("§cFailed to add items to pouch (may be full or not registered)!");
+            return false;
+        }
+    }
+
+    /**
+     * Get total amount of a material type across all tiers in pouch
+     */
+    public int getTotalInPouch(UUID playerUuid, MaterialType materialType) {
+        if (!enabled || pouchAPI == null) {
+            return 0;
+        }
+
+        int total = 0;
+        for (int tier = 1; tier <= 3; tier++) {
+            String itemKey = getPouchItemKey(materialType, tier);
+            try {
+                Object current = getItemQuantityMethod.invoke(pouchAPI, playerUuid.toString(), itemKey);
+                total += current instanceof Integer ? (Integer) current : 0;
+            } catch (Exception ignored) {
+                // ignore and continue
+            }
+        }
+
+        return total;
+    }
+
+    /**
+     * Force reload the integration (useful after IngredientPouch plugin is loaded)
+     */
+    public void reload() {
+        enabled = false;
+        pouchAPI = null;
+        initialize();
+    }
 }
+

--- a/src/main/java/org/maks/farmingPlugin/materials/MaterialManager.java
+++ b/src/main/java/org/maks/farmingPlugin/materials/MaterialManager.java
@@ -1,19 +1,27 @@
 package org.maks.farmingPlugin.materials;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemFlag;
-import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataType;
 import org.maks.farmingPlugin.FarmingPlugin;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 
+/**
+ * Handles creation and identification of custom farming materials.
+ * The class stores both the material type and tier in item metadata and
+ * provides several utility methods for working with player inventories.
+ */
 public class MaterialManager {
     private final FarmingPlugin plugin;
     private final NamespacedKey materialKey;
@@ -25,58 +33,78 @@ public class MaterialManager {
         this.tierKey = new NamespacedKey(plugin, "farmer_tier");
     }
 
+    /**
+     * Create a farming material item stack.
+     * Stores a full ID in PersistentDataContainer in format farmer_[id]_TIER
+     * to maintain compatibility with IngredientPouch plugin.
+     */
     public ItemStack createMaterial(MaterialType type, int tier, int amount) {
         ItemStack item = new ItemStack(type.getMaterial(), amount);
         ItemMeta meta = item.getItemMeta();
-        
+
         if (meta != null) {
             String tierRoman = getTierRoman(tier);
             String tierColor = getTierColor(tier);
-            String displayName = ChatColor.translateAlternateColorCodes('&', 
-                tierColor + "[ " + tierRoman + " ] " + type.getDisplayName());
-            
+            String displayName = ChatColor.translateAlternateColorCodes('&',
+                    tierColor + "[ " + tierRoman + " ] " + type.getDisplayName());
+
             meta.setDisplayName(displayName);
-            
+
             List<String> lore = new ArrayList<>();
             lore.add(ChatColor.translateAlternateColorCodes('&', type.getRarity().getLoreDescription()));
             meta.setLore(lore);
-            
+
             meta.addEnchant(Enchantment.DURABILITY, 10, true);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
             meta.setUnbreakable(true);
-            
-            meta.getPersistentDataContainer().set(materialKey, PersistentDataType.STRING, 
-                "farmer_" + type.getId() + "_" + tierRoman);
+
+            // Store full ID compatible with IngredientPouch
+            String fullId = "farmer_" + type.getId() + "_" + tierRoman;
+            meta.getPersistentDataContainer().set(materialKey, PersistentDataType.STRING, fullId);
             meta.getPersistentDataContainer().set(tierKey, PersistentDataType.INTEGER, tier);
-            
+
             item.setItemMeta(meta);
         }
-        
+
         return item;
     }
 
+    /**
+     * Determine whether the provided item is a farming material.
+     */
     public boolean isFarmingMaterial(ItemStack item) {
         if (item == null || !item.hasItemMeta()) {
             return false;
         }
-        
+
         ItemMeta meta = item.getItemMeta();
 
+        // First check NBT/PDC
         if (meta.getPersistentDataContainer().has(materialKey, PersistentDataType.STRING)) {
             return true;
         }
 
+        // Fallback to display name check
         if (!meta.hasDisplayName()) {
             return false;
         }
 
-        String stripped = ChatColor.stripColor(meta.getDisplayName());
-        MaterialType type = parseMaterialType(stripped);
-        int tier = parseTier(stripped);
+        String displayName = meta.getDisplayName();
+        String stripped = ChatColor.stripColor(displayName);
 
-        return type != null && tier > 0;
+        // Check pattern like "[ I ] Material"
+        if (stripped.matches("\\[\\s*[IVX]+\\s*\\].*")) {
+            MaterialType type = parseMaterialType(stripped);
+            int tier = parseTier(stripped);
+            return type != null && tier > 0;
+        }
+
+        return false;
     }
 
+    /**
+     * Get the material type represented by an item.
+     */
     public MaterialType getMaterialType(ItemStack item) {
         if (item == null || !item.hasItemMeta()) {
             return null;
@@ -84,16 +112,20 @@ public class MaterialManager {
 
         ItemMeta meta = item.getItemMeta();
 
+        // Check NBT/PDC first
         String materialId = meta.getPersistentDataContainer().get(materialKey, PersistentDataType.STRING);
 
-        if (materialId != null && materialId.startsWith("farmer_")) {
-            String[] parts = materialId.substring(7).split("_");
-            if (parts.length >= 2) {
-                String typeId = String.join("_", Arrays.copyOf(parts, parts.length - 1));
-                return MaterialType.fromId(typeId);
+        if (materialId != null) {
+            if (materialId.startsWith("farmer_")) {
+                // Remove prefix and tier suffix
+                String cleanId = materialId.substring(7);
+                cleanId = cleanId.replaceAll("_[IVX]+$", "");
+                return MaterialType.fromId(cleanId);
             }
+            return MaterialType.fromId(materialId);
         }
 
+        // Fallback to display name parsing
         if (meta.hasDisplayName()) {
             String stripped = ChatColor.stripColor(meta.getDisplayName());
             return parseMaterialType(stripped);
@@ -102,6 +134,9 @@ public class MaterialManager {
         return null;
     }
 
+    /**
+     * Get the tier of the farming material item.
+     */
     public int getMaterialTier(ItemStack item) {
         if (item == null || !item.hasItemMeta()) {
             return 0;
@@ -109,10 +144,20 @@ public class MaterialManager {
 
         ItemMeta meta = item.getItemMeta();
 
+        // Check NBT/PDC first
         if (meta.getPersistentDataContainer().has(tierKey, PersistentDataType.INTEGER)) {
-            return meta.getPersistentDataContainer().getOrDefault(tierKey, PersistentDataType.INTEGER, 0);
+            return meta.getPersistentDataContainer().get(tierKey, PersistentDataType.INTEGER);
         }
 
+        // Check material key for tier info
+        String materialId = meta.getPersistentDataContainer().get(materialKey, PersistentDataType.STRING);
+        if (materialId != null) {
+            if (materialId.endsWith("_III")) return 3;
+            if (materialId.endsWith("_II")) return 2;
+            if (materialId.endsWith("_I")) return 1;
+        }
+
+        // Fallback to display name parsing
         if (meta.hasDisplayName()) {
             String stripped = ChatColor.stripColor(meta.getDisplayName());
             return parseTier(stripped);
@@ -139,16 +184,29 @@ public class MaterialManager {
         };
     }
 
+    /**
+     * Try to parse a material type from a stripped display name.
+     * Supports some legacy/alias names for compatibility.
+     */
     private MaterialType parseMaterialType(String strippedName) {
         if (strippedName == null) {
             return null;
         }
 
+        // Pattern: "[ TIER ] Material Name"
         int endBracket = strippedName.indexOf(']');
-        if (strippedName.startsWith("[") && endBracket > 0) {
+        if (strippedName.startsWith("[") && endBracket > 0 && endBracket < strippedName.length() - 1) {
             String namePart = strippedName.substring(endBracket + 1).trim();
+
             for (MaterialType type : MaterialType.values()) {
                 if (type.getDisplayName().equalsIgnoreCase(namePart)) {
+                    return type;
+                }
+                // Legacy/alias names
+                if (namePart.equalsIgnoreCase("Herbal Extract") && type == MaterialType.HERB_EXTRACT) {
+                    return type;
+                }
+                if (namePart.equalsIgnoreCase("Ancient Grain Sheaf") && type == MaterialType.ANCIENT_GRAIN) {
                     return type;
                 }
             }
@@ -157,6 +215,9 @@ public class MaterialManager {
         return null;
     }
 
+    /**
+     * Parse tier from a stripped display name.
+     */
     private int parseTier(String strippedName) {
         if (strippedName == null) {
             return 0;
@@ -165,8 +226,8 @@ public class MaterialManager {
         if (strippedName.startsWith("[")) {
             int end = strippedName.indexOf(']');
             if (end > 0) {
-                String roman = strippedName.substring(1, end).trim().toUpperCase(Locale.ROOT);
-                return switch (roman) {
+                String tierPart = strippedName.substring(1, end).trim();
+                return switch (tierPart.toUpperCase(Locale.ROOT)) {
                     case "I" -> 1;
                     case "II" -> 2;
                     case "III" -> 3;
@@ -177,4 +238,105 @@ public class MaterialManager {
 
         return 0;
     }
+
+    /**
+     * Get the full IngredientPouch-compatible item ID
+     */
+    public String getPouchItemId(MaterialType type, int tier) {
+        return "farmer_" + type.getId() + "_" + getTierRoman(tier);
+    }
+
+    // ---------------------------------------------------------------------
+    // Inventory helper methods used by pouch integration and elsewhere
+    // ---------------------------------------------------------------------
+
+    /**
+     * Count a specific farming material in the player's inventory.
+     */
+    public int countMaterialInInventory(Player player, MaterialType materialType, int tier) {
+        int count = 0;
+
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null) continue;
+
+            if (isFarmingMaterial(item)) {
+                MaterialType itemType = getMaterialType(item);
+                int itemTier = getMaterialTier(item);
+
+                if (itemType == materialType && itemTier == tier) {
+                    count += item.getAmount();
+                }
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Remove a specific amount of material from the player's inventory.
+     *
+     * @return amount actually removed
+     */
+    public int removeMaterialFromInventory(Player player, MaterialType materialType, int tier, int amount) {
+        int remaining = amount;
+
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null || remaining <= 0) continue;
+
+            if (isFarmingMaterial(item)) {
+                MaterialType itemType = getMaterialType(item);
+                int itemTier = getMaterialTier(item);
+
+                if (itemType == materialType && itemTier == tier) {
+                    int stackSize = item.getAmount();
+
+                    if (stackSize <= remaining) {
+                        item.setAmount(0);
+                        remaining -= stackSize;
+                    } else {
+                        item.setAmount(stackSize - remaining);
+                        remaining = 0;
+                    }
+                }
+            }
+        }
+
+        player.updateInventory();
+        return amount - remaining;
+    }
+
+    /**
+     * Give a farming material to the player, dropping any leftovers if the
+     * inventory is full.
+     */
+    public void givePlayerMaterial(Player player, MaterialType materialType, int tier, int amount) {
+        ItemStack material = createMaterial(materialType, tier, amount);
+
+        HashMap<Integer, ItemStack> leftover = player.getInventory().addItem(material);
+
+        if (!leftover.isEmpty()) {
+            leftover.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
+            player.sendMessage(ChatColor.YELLOW + "Your inventory was full! Some items were dropped.");
+        }
+    }
+
+    /**
+     * Check if the player has at least a certain number of empty inventory
+     * slots.
+     */
+    public boolean hasInventorySpace(Player player, int slots) {
+        int emptySlots = 0;
+
+        for (ItemStack item : player.getInventory().getStorageContents()) {
+            if (item == null || item.getType() == Material.AIR) {
+                emptySlots++;
+                if (emptySlots >= slots) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }
+


### PR DESCRIPTION
## Summary
- Store full material IDs and tier info in item metadata for consistent detection
- Rewrite IngredientPouch integration with unified item key mapping and inventory helpers
- Use reflection to load IngredientPouch API at runtime and remove compile dependency
- Wrap reflective API calls to avoid unhandled invocation and access exceptions

## Testing
- `mvn -q -e -DskipTests=true compile` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aed05b2568832a88d7cf9e704a1f96